### PR TITLE
Add getsockopt method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,9 +319,8 @@ impl NanoSocket {
         }
     }
 
-
+    #[inline(never)]
     pub fn getsockopt(&self, level: i32, option: i32) -> Result<u32, NanoErr> {
-        #![inline(never)]
 
         unsafe {
             let mut optval: u32 = 0;


### PR DESCRIPTION
Adds the corresponding rust function for `nn_getsockopt`, which retrieves the socket option for the
specified (level, option) tuple.

The tests are a bit janky, could easily be refactored into a map of test -> response pairs and looped, instead of a big list of asserts :)

Example usage:

```
        let addr="tcp://127.0.0.1:8898";

        let mut sock = match NanoSocket::new(AF_SP, NN_PAIR) {
            Ok(s) => s,
            Err(_) => fail!("asdf")
        };

        sock.bind(addr);

        // Linger default is 1000ms
        let ret = match sock.getsockopt(NN_SOL_SOCKET, NN_LINGER) {
          Ok(s) => s,
          Err(e) => fail!("failed getsockopt(NN_SOL_SOCKET, NN_LINGER) with err:{:?} {:?}", e.rc, e.errstr)
        };

        assert!(ret == 1000);
```

More examples in the added tests.
