### PR TITLE
Fixes issue #50 : API doesn't work with Reader API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,7 +583,6 @@ mod tests {
     extern crate libc;
 
     use super::*;
-    use endpoint::Endpoint;
 
     use std::time::duration::Duration;
     use std::io::timer::sleep;


### PR DESCRIPTION
Adds an implementation for Reader.read_to_end.
Removes unstable attribute from trait functions.
