### PR TITLE
Fixes proc() usage againt rustc nightly 126db549b 2014-12-15

### DIFF
--- a/libnanomsg/src/lib.rs
+++ b/libnanomsg/src/lib.rs
@@ -575,7 +575,7 @@ mod tests {
         let drop_after_use_pull = drop_after_use.clone();
         let drop_after_use_push = drop_after_use.clone();
 
-        spawn(proc() {
+        spawn(move || {
             let url = name.to_c_str();
             let push_msg = "foobar";
             let push_sock = test_create_socket(AF_SP, NN_PUSH);
@@ -586,7 +586,7 @@ mod tests {
             finish_child_task(drop_after_use_push, push_sock, push_endpoint, finish_line_push);
         });
 
-        spawn(proc() {
+        spawn(move || {
             let url = name.to_c_str();
             let pull_msg = "foobar";
             let pull_sock = test_create_socket(AF_SP, NN_PULL);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,7 +681,7 @@ mod tests {
         let finish_line_pull = finish_line.clone();
         let finish_line_push = finish_line.clone();
 
-        spawn(proc() {
+        spawn(move || {
             let mut push_socket = test_create_socket(Push);
             
             test_bind(&mut push_socket, url);
@@ -690,7 +690,7 @@ mod tests {
             finish_line_push.wait();
         });
 
-        spawn(proc() {
+        spawn(move|| {
             let mut pull_socket = test_create_socket(Pull);
 
             test_connect(&mut pull_socket, url);


### PR DESCRIPTION
- Replaces calls to obsolete `proc()` by `move ||`.
