### PR TITLE
Use CString to pass Rust strings to C

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use endpoint::Endpoint;
 use libnanomsg::nn_pollfd;
 
 use libc::{c_int, c_void, size_t};
+use std::ffi::CString;
 use std::mem::transmute;
 use std::ptr;
 use result::last_nano_error;
@@ -270,7 +271,7 @@ impl Socket {
     /// - `Terminating` : The library is terminating.
     #[unstable]
     pub fn bind(&mut self, addr: &str) -> NanoResult<Endpoint> {
-        let ret = unsafe { libnanomsg::nn_bind(self.socket, addr.as_ptr() as *const i8) };
+        let ret = unsafe { libnanomsg::nn_bind(self.socket, CString::from_slice(addr.as_bytes()).as_ptr()) };
 
         error_guard!(ret);
         Ok(Endpoint::new(ret, self.socket))
@@ -306,7 +307,7 @@ impl Socket {
     /// - `Terminating` : The library is terminating.
     #[unstable]
     pub fn connect(&mut self, addr: &str) -> NanoResult<Endpoint> {
-        let ret = unsafe { libnanomsg::nn_connect(self.socket, addr.as_ptr() as *const i8) };
+        let ret = unsafe { libnanomsg::nn_connect(self.socket, CString::from_slice(addr.as_bytes()).as_ptr()) };
 
         error_guard!(ret);
         Ok(Endpoint::new(ret, self.socket))


### PR DESCRIPTION
The bind and connect methods on Socket both pass pointers to Rust strings directly down to nanomsg. As a result, socket names might pick up other strings in your code. [This gist](https://gist.github.com/mystal/1d0563109e53deff3794) shows an example. The socket should be `my_socket.ipc`, but instead it is `my_socket.ipctext`.

In this PR, I create a CString and pass a pointer to it down to nanomsg.