### PR TITLE
Zero-copy option for send operation

### DIFF
--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,3 +1,4 @@
+#![feature(core, std_misc, io, os)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;

--- a/examples/reqrep.rs
+++ b/examples/reqrep.rs
@@ -1,3 +1,4 @@
+#![feature(core, std_misc, io, os)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;

--- a/nanomsg-sys/src/lib.rs
+++ b/nanomsg-sys/src/lib.rs
@@ -54,6 +54,8 @@ pub const NN_SOCKET_NAME: c_int = 15;
 
 pub const NN_DONTWAIT: c_int = 1;
 
+pub const NN_INPROC: c_int = -1;
+pub const NN_IPC: c_int = -2;
 pub const NN_TCP: c_int = -3;
 
 pub const NN_TCP_NODELAY: c_int = 1;


### PR DESCRIPTION
 - Implements the zero-copy version of `write` function
 - Removes some warnings from the examples.