### PR TITLE
Fixes build against rustc 1.0.0-nightly 2015-02-19

### DIFF
--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,4 +1,4 @@
-#![feature(core, std_misc, io, os)]
+#![feature(core, std_misc, io, old_io, os)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;

--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,4 +1,4 @@
-#![feature(core, std_misc, io, old_io, os)]
+#![feature(core, std_misc, io, old_io, env)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;
@@ -83,7 +83,7 @@ fn usage() {
 }
 
 fn main() {
-    let args = std::os::args();
+    let args: Vec<_> = std::env::args().collect();
 
     if args.len() < 2 {
         return usage()

--- a/examples/reqrep.rs
+++ b/examples/reqrep.rs
@@ -1,4 +1,4 @@
-#![feature(core, std_misc, io, old_io, os)]
+#![feature(core, std_misc, io, old_io, env)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;
@@ -34,8 +34,8 @@ fn client() {
 
         match socket.read_to_string(&mut reply) {
             Ok(_) => {
-                reply.clear();
-                println!("Recv '{}'.", reply.as_slice())
+                println!("Recv '{}'.", reply.as_slice());
+                reply.clear()
             },
             Err(err) => {
                 println!("Client failed to receive reply '{}'.", err);
@@ -109,7 +109,7 @@ fn usage() {
 }
 
 fn main() {
-    let args = std::os::args();
+    let args: Vec<_> = std::env::args().collect();
 
     if args.len() < 2 {
         return usage()

--- a/examples/reqrep.rs
+++ b/examples/reqrep.rs
@@ -1,4 +1,4 @@
-#![feature(core, std_misc, io, os)]
+#![feature(core, std_misc, io, old_io, os)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;

--- a/nanomsg-sys/src/lib.rs
+++ b/nanomsg-sys/src/lib.rs
@@ -294,6 +294,7 @@ extern {
 mod tests {
     use super::*;
     use libc::{c_int, c_void, size_t, c_char, c_short};
+    use std::slice;
     use std::ptr;
     use std::mem::transmute;
 
@@ -333,7 +334,7 @@ mod tests {
         let mut buf: *mut u8 = ptr::null_mut();
         let bytes = unsafe { nn_recv(socket, transmute(&mut buf), NN_MSG, 0 as c_int) };
         assert!(bytes >= 0);
-        let msg = unsafe { Vec::from_raw_buf(buf, bytes as usize) };
+        let msg = unsafe { slice::from_raw_parts_mut(buf, bytes as usize) };
         assert_eq!(msg, expected.as_bytes());
         unsafe { nn_freemsg(buf as *mut c_void); }
     }

--- a/nanomsg-sys/src/lib.rs
+++ b/nanomsg-sys/src/lib.rs
@@ -301,8 +301,7 @@ mod tests {
     use std::old_io::timer::sleep;
 
     use std::sync::{Arc, Barrier};
-    use std::thread::Thread;
-    use std::slice::from_raw_buf;
+    use std::thread;
 
     fn test_create_socket(domain: c_int, protocol: c_int) -> c_int {
         let sock = unsafe { nn_socket(domain, protocol) };
@@ -567,7 +566,7 @@ mod tests {
         let drop_after_use_pull = drop_after_use.clone();
         let drop_after_use_push = drop_after_use.clone();
 
-        let push_thread = Thread::scoped(move || {
+        let push_thread = thread::scoped(move || {
             let push_msg = "foobar";
             let push_sock = test_create_socket(AF_SP, NN_PUSH);
             let push_endpoint = test_bind(push_sock, url.as_ptr() as *const i8);
@@ -577,7 +576,7 @@ mod tests {
             finish_child_task(drop_after_use_push, push_sock, push_endpoint);
         });
 
-        let pull_thread = Thread::scoped(move || {
+        let pull_thread = thread::scoped(move || {
             let pull_msg = "foobar";
             let pull_sock = test_create_socket(AF_SP, NN_PULL);
             let pull_endpoint = test_connect(pull_sock, url.as_ptr() as *const i8);
@@ -587,8 +586,8 @@ mod tests {
             finish_child_task(drop_after_use_pull, pull_sock, pull_endpoint);
         });
 
-        assert!(push_thread.join().is_ok());
-        assert!(pull_thread.join().is_ok());
+        push_thread.join();
+        pull_thread.join();
     }
 
     #[test]

--- a/nanomsg-sys/src/lib.rs
+++ b/nanomsg-sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, link_args, libc)]
+#![feature(libc)]
 #![allow(non_camel_case_types)]
 #[link(name = "nanomsg", kind = "static")]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1327,8 +1327,8 @@ mod tests {
 
         finish_line.wait();
 
-        assert!(push_thread.join().is_ok());
-        assert!(pull_thread.join().is_ok());
+        push_thread.join();
+        pull_thread.join();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(slicing_syntax, plugin, libc, core, std_misc, collections, io)]
+#![feature(plugin, libc, core, std_misc, collections, io)]
 
 extern crate libc;
 extern crate "nanomsg-sys" as libnanomsg;
@@ -11,14 +11,15 @@ use libnanomsg::nn_pollfd;
 use libc::{c_int, c_void, size_t};
 use std::ffi::CString;
 use std::mem::transmute;
+use std::str;
 use std::ptr;
 use result::last_nano_error;
-use std::old_io::{Writer, Reader, IoResult};
-use std::old_io;
+use std::io;
 use std::mem::size_of;
 use std::time::duration::Duration;
 use std::marker::NoCopy;
 use std::slice;
+use std::error::FromError;
 
 pub mod result;
 pub mod endpoint;
@@ -189,6 +190,16 @@ macro_rules! error_guard(
     )
 );
 
+macro_rules! io_error_guard(
+    ($ret:ident) => (
+        if $ret == -1 {
+            let nano_err = last_nano_error();
+            let io_err = FromError::from_error(nano_err);
+            return Err(io_err);
+        }
+    )
+);
+
 impl Socket {
 
     /// Allocate and initialize a new Nanomsg socket which returns
@@ -285,7 +296,11 @@ impl Socket {
     /// - `Terminating` : The library is terminating.
     #[unstable]
     pub fn bind(&mut self, addr: &str) -> NanoResult<Endpoint> {
-        let ret = unsafe { libnanomsg::nn_bind(self.socket, CString::from_slice(addr.as_bytes()).as_ptr()) };
+        let c_addr = CString::new(addr.as_bytes());
+        if c_addr.is_err() {
+            return Err(NanoError::from_nn_errno(libnanomsg::EINVAL));
+        }
+        let ret = unsafe { libnanomsg::nn_bind(self.socket, c_addr.unwrap().as_ptr()) };
 
         error_guard!(ret);
         Ok(Endpoint::new(ret, self.socket))
@@ -321,7 +336,11 @@ impl Socket {
     /// - `Terminating` : The library is terminating.
     #[unstable]
     pub fn connect(&mut self, addr: &str) -> NanoResult<Endpoint> {
-        let ret = unsafe { libnanomsg::nn_connect(self.socket, CString::from_slice(addr.as_bytes()).as_ptr()) };
+        let c_addr = CString::new(addr.as_bytes());
+        if c_addr.is_err() {
+            return Err(NanoError::from_nn_errno(libnanomsg::EINVAL));
+        }
+        let ret = unsafe { libnanomsg::nn_connect(self.socket, c_addr.unwrap().as_ptr()) };
 
         error_guard!(ret);
         Ok(Endpoint::new(ret, self.socket))
@@ -479,6 +498,7 @@ impl Socket {
     ///
     /// ```rust
     /// use nanomsg::{Socket, Protocol};
+    /// use std::io::{Read, Write};
     ///
     /// let mut push_socket = Socket::new(Protocol::Push).unwrap();
     /// let mut push_endpoint = push_socket.bind("ipc:///tmp/zc_write_doc.ipc").unwrap();
@@ -496,7 +516,8 @@ impl Socket {
     ///     Ok(_) => { println!("Message sent, do not try to reuse it !"); },
     ///     Err(err) => panic!("Problem while writing: {}, msg still available", err)
     /// };
-    /// match pull_socket.read_to_string() {
+    /// let mut text = String::new();
+    /// match pull_socket.read_to_string(&mut text) {
     ///     Ok(_) => { println!("Message received."); },
     ///     Err(err) => panic!("{}", err)
     /// }
@@ -589,7 +610,7 @@ impl Socket {
     /// #![allow(unstable)]
     /// use nanomsg::{Socket, Protocol, PollFd, PollRequest};
     /// use std::time::duration::Duration;
-    /// use std::old_io::timer::sleep;
+    /// use std::old_io::timer;
     ///
     /// let mut left_socket = Socket::new(Protocol::Pair).unwrap();
     /// let mut left_ep = left_socket.bind("ipc:///tmp/poll_doc.ipc").unwrap();
@@ -597,7 +618,7 @@ impl Socket {
     /// let mut right_socket = Socket::new(Protocol::Pair).unwrap();
     /// let mut right_ep = right_socket.connect("ipc:///tmp/poll_doc.ipc").unwrap();
     /// 
-    /// sleep(Duration::milliseconds(10));
+    /// timer::sleep(Duration::milliseconds(10));
     ///
     /// // Here some messages may have been sent ...
     ///
@@ -690,8 +711,11 @@ impl Socket {
     }
 
     fn set_socket_options_str(&self, level: c_int, option: c_int, val: &str) -> NanoResult<()> {
-        let c_val = CString::from_slice(val.as_bytes());
-        let ptr = c_val.as_ptr() as *const c_void;
+        let c_val = CString::new(val.as_bytes());
+        if c_val.is_err() {
+            return Err(NanoError::from_nn_errno(libnanomsg::EINVAL));
+        }
+        let ptr = c_val.unwrap().as_ptr() as *const c_void;
         let ret = unsafe {
             libnanomsg::nn_setsockopt(self.socket,
                                       level,
@@ -873,7 +897,7 @@ impl Socket {
 
 }
 
-impl Reader for Socket {
+impl io::Read for Socket {
     /// Receive a message from the socket and store it in the buf argument.
     /// Any bytes exceeding the length specified by `buf.len()` will be truncated.
     /// Returns the number of bytes in the message on success.
@@ -884,7 +908,8 @@ impl Reader for Socket {
     /// #![allow(unstable)]
     /// use nanomsg::{Socket, Protocol};
     /// use std::time::duration::Duration;
-    /// use std::old_io::timer::sleep;
+    /// use std::old_io::timer;
+    /// use std::io::{Read, Write};
     ///
     /// let mut push_socket = Socket::new(Protocol::Push).unwrap();
     /// let mut push_ep = push_socket.bind("ipc:///tmp/read_doc.ipc").unwrap();
@@ -893,7 +918,7 @@ impl Reader for Socket {
     /// let mut pull_ep = pull_socket.connect("ipc:///tmp/read_doc.ipc").unwrap();
     /// let mut buffer = [0u8; 1024];
     /// 
-    /// sleep(Duration::milliseconds(50));
+    /// timer::sleep(Duration::milliseconds(50));
     /// 
     /// match push_socket.write(b"foobar") {
     ///     Ok(..) => println!("Message sent !"),
@@ -911,28 +936,24 @@ impl Reader for Socket {
     ///
     /// # Error
     ///
-    /// - `BadFileDescriptor` : The socket is invalid.
-    /// - `OperationNotSupported` : The operation is not supported by this socket type.
-    /// - `FileStateMismatch` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
-    /// - `TryAgain` : Non-blocking mode was requested and there’s no message to receive at the moment.
-    /// - `Timeout` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
-    /// - `Interrupted` : The operation was interrupted by delivery of a signal before the message was received.
-    /// - `Terminating` : The library is terminating.
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+    /// - `io::ErrorKind::FileNotFound` : The socket is invalid.
+    /// - `io::ErrorKind::MismatchedFileTypeForOperation` : The operation is not supported by this socket type.
+    /// - `io::ErrorKind::ResourceUnavailable` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
+    /// - `io::ErrorKind::TimedOut` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
+    /// - `io::ErrorKind::Interrupted` : The operation was interrupted by delivery of a signal before the message was received.
+    /// - `io::ErrorKind::Other` : The library is terminating.
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
 
         let buf_len = buf.len() as size_t;
         let buf_ptr = buf.as_mut_ptr();
         let c_buf_ptr = buf_ptr as *mut c_void;
         let ret = unsafe { libnanomsg::nn_recv(self.socket, c_buf_ptr, buf_len, 0 as c_int) };
 
-        if ret == -1 {
-            return Err(last_nano_error().to_ioerror());
-        }
-
+        io_error_guard!(ret);
         Ok(ret as usize)
     }
 
-    /// Receive a message from the socket. Returns a message allocated by nanomsg on success.
+    /// Receive a message from the socket. Copy the message allocated by nanomsg into the buffer on success.
     ///
     /// # Example:
     ///
@@ -940,7 +961,8 @@ impl Reader for Socket {
     /// #![allow(unstable)]
     /// use nanomsg::{Socket, Protocol};
     /// use std::time::duration::Duration;
-    /// use std::old_io::timer::sleep;
+    /// use std::old_io::timer;
+    /// use std::io::{Read, Write};
     ///
     /// let mut push_socket = Socket::new(Protocol::Push).unwrap();
     /// let mut push_ep = push_socket.bind("ipc:///tmp/read_to_end_doc.ipc").unwrap();
@@ -948,15 +970,16 @@ impl Reader for Socket {
     /// let mut pull_socket = Socket::new(Protocol::Pull).unwrap();
     /// let mut pull_ep = pull_socket.connect("ipc:///tmp/read_to_end_doc.ipc").unwrap();
     /// 
-    /// sleep(Duration::milliseconds(50));
+    /// timer::sleep(Duration::milliseconds(50));
     /// 
     /// match push_socket.write(b"foobar") {
     ///     Ok(..) => println!("Message sent !"),
     ///     Err(err) => panic!("Failed to write to the socket: {}", err)
     /// }
     ///
-    /// match pull_socket.read_to_end() {
-    ///     Ok(msg) => { 
+    /// let mut msg = Vec::new();
+    /// match pull_socket.read_to_end(&mut msg) {
+    ///     Ok(_) => { 
     ///         println!("Read {} bytes !", msg.as_slice().len()); 
     ///         // here we can process the the message stored in `msg`
     ///     },
@@ -966,13 +989,13 @@ impl Reader for Socket {
     ///
     /// # Error
     ///
-    /// - `IoErrorKind::FileNotFound` : The socket is invalid.
-    /// - `IoErrorKind::MismatchedFileTypeForOperation` : The operation is not supported by this socket type.
-    /// - `IoErrorKind::ResourceUnavailable` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
-    /// - `IoErrorKind::BrokenPipe` : The operation was interrupted by delivery of a signal before the message was received.
-    /// - `IoErrorKind::TimedOut` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
-    /// - `IoErrorKind::IoUnavailable` : The library is terminating.
-    fn read_to_end(&mut self) -> IoResult<Vec<u8>> {
+    /// - `io::ErrorKind::FileNotFound` : The socket is invalid.
+    /// - `io::ErrorKind::MismatchedFileTypeForOperation` : The operation is not supported by this socket type.
+    /// - `io::ErrorKind::ResourceUnavailable` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
+    /// - `io::ErrorKind::TimedOut` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
+    /// - `io::ErrorKind::Interrupted` : The operation was interrupted by delivery of a signal before the message was received.
+    /// - `io::ErrorKind::Other` : The library is terminating.
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<()> {
         let mut mem : *mut u8 = ptr::null_mut();
 
         let ret = unsafe {
@@ -983,55 +1006,48 @@ impl Reader for Socket {
                 0 as c_int)
         };
 
-        if ret == -1 {
-            return Err(last_nano_error().to_ioerror());
-        }
+        io_error_guard!(ret);
 
-        let len = ret as usize;
         unsafe {
-            let bytes = Vec::from_raw_buf(mem as *const _, len);
+            let bytes = slice::from_raw_parts(mem as *const _, ret as usize);
+            buf.push_all(bytes);
             libnanomsg::nn_freemsg(mem as *mut c_void);
-            Ok(bytes)
+            Ok(())
         }
     }
 
-    /// Reads at least `min` bytes and places them in `buf`.
-    /// Returns the number of bytes read.
-    ///
-    /// This will continue to call `read` until at least `min` bytes have been
-    ///
-    /// If an error occurs at any point, that error is returned, and no further bytes are read.
-    ///
-    /// # Error
-    ///
-    /// - `IoErrorKind::FileNotFound` : The socket is invalid.
-    /// - `IoErrorKind::MismatchedFileTypeForOperation` : The operation is not supported by this socket type.
-    /// - `IoErrorKind::ResourceUnavailable` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
-    /// - `IoErrorKind::BrokenPipe` : The operation was interrupted by delivery of a signal before the message was received.
-    /// - `IoErrorKind::TimedOut` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
-    /// - `IoErrorKind::IoUnavailable` : The library is terminating.
-    fn read_at_least(&mut self, min: usize, buf: &mut [u8]) -> IoResult<usize> {
-        if min > buf.len() {
-            return Err(old_io::standard_error(old_io::InvalidInput));
-        }
-        let mut read = 0;
-        while read < min {
-            loop {
-                let write_buf = &mut buf[read..];
-                match self.read(write_buf) {
-                    Ok(n) => {
-                        read += std::cmp::min(n, write_buf.len());
-                        break;
-                    }
-                    err@Err(_) => return err
-                }
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<()> {
+        let mut mem : *mut u8 = ptr::null_mut();
+
+        let ret = unsafe {
+            libnanomsg::nn_recv(
+                self.socket,
+                transmute(&mut mem),
+                libnanomsg::NN_MSG,
+                0 as c_int)
+        };
+
+        io_error_guard!(ret);
+
+        unsafe {
+            let bytes = slice::from_raw_parts(mem as *const _, ret as usize);
+            match str::from_utf8(bytes) {
+                Ok(text) => {
+                    buf.push_str(text);
+                    libnanomsg::nn_freemsg(mem as *mut c_void);
+                    Ok(())
+                },
+                Err(_) => {
+                    libnanomsg::nn_freemsg(mem as *mut c_void);
+                    Err(io::Error::new(io::ErrorKind::Other, "UTF8 conversion failed !", None))
+                },
             }
         }
-        Ok(read)
     }
+
 }
 
-impl Writer for Socket {
+impl io::Write for Socket {
     /// The function will send a message containing the data from the buf parameter to the socket. 
     /// Which of the peers the message will be sent to is determined by the particular socket type.
     ///
@@ -1042,7 +1058,8 @@ impl Writer for Socket {
     /// #![allow(unstable)]
     /// use nanomsg::{Socket, Protocol};
     /// use std::time::duration::Duration;
-    /// use std::old_io::timer::sleep;
+    /// use std::old_io::timer;
+    /// use std::io::{Read, Write};
     ///
     /// let mut push_socket = Socket::new(Protocol::Push).unwrap();
     /// let mut push_ep = push_socket.bind("ipc:///tmp/write_doc.ipc").unwrap();
@@ -1051,7 +1068,7 @@ impl Writer for Socket {
     /// let mut pull_ep = pull_socket.connect("ipc:///tmp/write_doc.ipc").unwrap();
     /// let mut buffer = [0u8; 1024];
     /// 
-    /// sleep(Duration::milliseconds(50));
+    /// timer::sleep(Duration::milliseconds(50));
     /// 
     /// match push_socket.write_all(b"foobar") {
     ///     Ok(..) => println!("Message sent !"),
@@ -1069,23 +1086,23 @@ impl Writer for Socket {
     ///
     /// # Error
     ///
-    /// - `IoErrorKind::FileNotFound` : The socket is invalid.
-    /// - `IoErrorKind::MismatchedFileTypeForOperation` : The operation is not supported by this socket type.
-    /// - `IoErrorKind::ResourceUnavailable` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
-    /// - `IoErrorKind::BrokenPipe` : The operation was interrupted by delivery of a signal before the message was received.
-    /// - `IoErrorKind::TimedOut` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
-    /// - `IoErrorKind::IoUnavailable` : The library is terminating.
-    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
+    /// - `io::ErrorKind::FileNotFound` : The socket is invalid.
+    /// - `io::ErrorKind::MismatchedFileTypeForOperation` : The operation is not supported by this socket type.
+    /// - `io::ErrorKind::ResourceUnavailable` : The operation cannot be performed on this socket at the moment because socket is not in the appropriate state. This error may occur with socket types that switch between several states.
+    /// - `io::ErrorKind::Interrupted` : The operation was interrupted by delivery of a signal before the message was received.
+    /// - `io::ErrorKind::TimedOut` : Individual socket types may define their own specific timeouts. If such timeout is hit this error will be returned.
+    /// - `io::ErrorKind::Other` : The library is terminating.
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let len = buf.len();
         let ret = unsafe {
-            libnanomsg::nn_send(self.socket, buf.as_ptr() as *const c_void,
-                                len as size_t, 0)
+            libnanomsg::nn_send(self.socket, buf.as_ptr() as *const c_void, len as size_t, 0)
         };
 
-        if ret as usize != len {
-            return Err(last_nano_error().to_ioerror());
-        }
+        io_error_guard!(ret);
+        Ok(len)
+    }
 
+    fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 }
@@ -1110,10 +1127,11 @@ mod tests {
     use super::result::NanoErrorKind::*;
 
     use std::time::duration::Duration;
-    use std::old_io::timer::sleep;
+    use std::old_io::timer;
+    use std::io::{Read, Write};
 
     use std::sync::{Arc, Barrier};
-    use std::thread::Thread;
+    use std::thread;
 
     #[test]
     fn check_allocate() {
@@ -1222,7 +1240,7 @@ mod tests {
 
     fn test_zc_write(socket: &mut Socket, buf: &[u8]) {
         let mut msg = Socket::allocate_msg(buf.len()).unwrap();
-        for i in range(0us, buf.len()) {
+        for i in range(0, buf.len()) {
            msg[i] = buf[i]; 
         }
         match socket.zc_write(msg) {
@@ -1243,8 +1261,9 @@ mod tests {
     }
 
     fn test_read_to_string(socket: &mut Socket, expected: &str) {
-        match socket.read_to_string() {
-            Ok(text) => assert_eq!(text.as_slice(), expected),
+        let mut text = String::new();
+        match socket.read_to_string(&mut text) {
+            Ok(_) => assert_eq!(text.as_slice(), expected),
             Err(err) => panic!("{}", err)
         }
     }
@@ -1254,6 +1273,10 @@ mod tests {
             Ok(_) => {},
             Err(err) => panic!("{}", err)
         }
+    }
+
+    fn sleep_some_millis(millis: i64) {
+        timer::sleep(Duration::milliseconds(millis));
     }
 
     #[test]
@@ -1267,7 +1290,7 @@ mod tests {
         let mut pull_socket = test_create_socket(Pull);
         test_connect(&mut pull_socket, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         test_write(&mut push_socket, b"foobar");
         test_read(&mut pull_socket, b"foobar");
@@ -1289,7 +1312,7 @@ mod tests {
         let mut pull_socket = test_create_socket(Pull);
         test_connect(&mut pull_socket, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         test_zc_write(&mut push_socket, b"foobar");
         test_read(&mut pull_socket, b"foobar");
@@ -1307,7 +1330,7 @@ mod tests {
         let finish_line_pull = finish_line.clone();
         let finish_line_push = finish_line.clone();
 
-        let push_thread = Thread::scoped(move || {
+        let push_thread = thread::scoped(move || {
             let mut push_socket = test_create_socket(Push);
             
             test_bind(&mut push_socket, url);
@@ -1316,7 +1339,7 @@ mod tests {
             finish_line_push.wait();
         });
 
-        let pull_thread = Thread::scoped(move|| {
+        let pull_thread = thread::scoped(move|| {
             let mut pull_socket = test_create_socket(Pull);
 
             test_connect(&mut pull_socket, url);
@@ -1352,7 +1375,7 @@ mod tests {
         let mut right_socket = test_create_socket(Pair);
         test_connect(&mut right_socket, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         test_write(&mut right_socket, b"foobar");
         test_read(&mut left_socket, b"foobar");
@@ -1378,7 +1401,7 @@ mod tests {
         let mut sock3 = test_create_socket(Bus);
         test_connect(&mut sock3, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         let msg = b"foobar";
         test_write(&mut sock1, msg);
@@ -1406,7 +1429,7 @@ mod tests {
         test_subscribe(&mut sock3, "bar");
         test_connect(&mut sock3, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         let msg1 = b"foobar";
         test_write(&mut sock1, msg1);
@@ -1435,7 +1458,7 @@ mod tests {
         let mut sock3 = test_create_socket(Respondent);
         test_connect(&mut sock3, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         let deadline = Duration::milliseconds(500);
         match sock1.set_survey_deadline(&deadline) {
@@ -1661,13 +1684,10 @@ mod tests {
         let mut right_socket = test_create_socket(Pair);
         test_connect(&mut right_socket, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         test_write(&mut right_socket, b"ok");
         test_read_to_string(&mut left_socket, "ok".as_slice());
-
-        test_write(&mut left_socket, b"");
-        test_read_to_string(&mut right_socket, "".as_slice());
 
         test_write(&mut left_socket, b"not ok");
         test_read_to_string(&mut right_socket, "not ok".as_slice());
@@ -1686,7 +1706,7 @@ mod tests {
 
         let mut pull_socket = test_create_socket(Pull);
         test_connect(&mut pull_socket, url);
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         let mut buf = [0u8; 6];
         match pull_socket.nb_read(&mut buf) {
@@ -1695,7 +1715,7 @@ mod tests {
         }
 
         test_write(&mut push_socket, b"foobar");
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         let mut buf = [0u8; 6];
         match pull_socket.nb_read(&mut buf) {
@@ -1720,7 +1740,7 @@ mod tests {
 
         let mut pull_socket = test_create_socket(Pull);
         test_connect(&mut pull_socket, url);
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         match pull_socket.nb_read_to_end() {
             Ok(_) => panic!("Nothing should have been received !"),
@@ -1728,7 +1748,7 @@ mod tests {
         }
 
         test_write(&mut push_socket, b"foobar");
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         match pull_socket.nb_read_to_end() {
             Ok(buf) => {
@@ -1749,7 +1769,7 @@ mod tests {
 
         let mut push_socket = test_create_socket(Push);
         test_bind(&mut push_socket, url);
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         match push_socket.nb_write(b"barfoo") {
             Ok(_) => panic!("Nothing should have been sent !"),
@@ -1769,7 +1789,7 @@ mod tests {
         let mut right_socket = test_create_socket(Pair);
         test_connect(&mut right_socket, url);
 
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
 
         let pollfd1 = left_socket.new_pollfd(true, true);
         let pollfd2 = right_socket.new_pollfd(true, true);
@@ -1795,7 +1815,7 @@ mod tests {
         }
 
         test_write(&mut right_socket, b"foobar");
-        sleep(Duration::milliseconds(10));
+        sleep_some_millis(10);
         {
             let poll_result = Socket::poll(&mut request, &timeout);
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,12 +3,10 @@ use libnanomsg;
 
 use std::str;
 use std::fmt;
-use std::old_io;
-use std::old_io::{IoError, IoErrorKind};
+use std::io;
 use std::error::FromError;
 use std::num::FromPrimitive;
-use std::ffi::c_str_to_bytes;
-use std::mem::transmute;
+use std::ffi::CStr;
 
 pub use self::NanoErrorKind::*;
 
@@ -16,40 +14,40 @@ pub type NanoResult<T> = Result<T, NanoError>;
 
 #[derive(Debug, Clone, PartialEq, FromPrimitive, Copy)]
 pub enum NanoErrorKind {
-    Unknown = 0is,
-    OperationNotSupported = libnanomsg::ENOTSUP as isize,
-    ProtocolNotSupported = libnanomsg::EPROTONOSUPPORT as isize,
-    NoBufferSpace = libnanomsg::ENOBUFS as isize,
-    NetworkDown = libnanomsg::ENETDOWN as isize,
-    AddressInUse = libnanomsg::EADDRINUSE as isize,
-    AddressNotAvailable = libnanomsg::EADDRNOTAVAIL as isize,
-    ConnectionRefused = libnanomsg::ECONNREFUSED as isize,
-    OperationNowInProgress = libnanomsg::EINPROGRESS as isize,
-    NotSocket = libnanomsg::ENOTSOCK as isize,
-    AddressFamilyNotSupported = libnanomsg::EAFNOSUPPORT as isize,
-    WrongProtocol = libnanomsg::EPROTO as isize,
-    TryAgain = libnanomsg::EAGAIN as isize,
-    BadFileDescriptor = libnanomsg::EBADF as isize,
-    InvalidArgument = libnanomsg::EINVAL as isize,
-    TooManyOpenFiles = libnanomsg::EMFILE as isize,
-    BadAddress = libnanomsg::EFAULT as isize,
-    PermisionDenied = libnanomsg::EACCESS as isize,
-    NetworkReset = libnanomsg::ENETRESET as isize,
-    NetworkUnreachable = libnanomsg::ENETUNREACH as isize,
-    HostUnreachable = libnanomsg::EHOSTUNREACH as isize,
-    NotConnected = libnanomsg::ENOTCONN as isize,
-    MessageTooLong = libnanomsg::EMSGSIZE as isize,
-    Timeout = libnanomsg::ETIMEDOUT as isize,
-    ConnectionAbort = libnanomsg::ECONNABORTED as isize,
-    ConnectionReset = libnanomsg::ECONNRESET as isize,
-    ProtocolNotAvailable = libnanomsg::ENOPROTOOPT as isize,
-    AlreadyConnected = libnanomsg::EISCONN as isize,
-    SocketTypeNotSupported = libnanomsg::ESOCKTNOSUPPORT as isize,
-    Terminating = libnanomsg::ETERM as isize,
-    NameTooLong = libnanomsg::ENAMETOOLONG as isize,
-    NoDevice = libnanomsg::ENODEV as isize,
-    FileStateMismatch = libnanomsg::EFSM as isize,
-    Interrupted = libnanomsg::EINTR as isize
+    Unknown                    = 0isize,
+    OperationNotSupported      = libnanomsg::ENOTSUP          as isize,
+    ProtocolNotSupported       = libnanomsg::EPROTONOSUPPORT  as isize,
+    NoBufferSpace              = libnanomsg::ENOBUFS          as isize,
+    NetworkDown                = libnanomsg::ENETDOWN         as isize,
+    AddressInUse               = libnanomsg::EADDRINUSE       as isize,
+    AddressNotAvailable        = libnanomsg::EADDRNOTAVAIL    as isize,
+    ConnectionRefused          = libnanomsg::ECONNREFUSED     as isize,
+    OperationNowInProgress     = libnanomsg::EINPROGRESS      as isize,
+    NotSocket                  = libnanomsg::ENOTSOCK         as isize,
+    AddressFamilyNotSupported  = libnanomsg::EAFNOSUPPORT     as isize,
+    WrongProtocol              = libnanomsg::EPROTO           as isize,
+    TryAgain                   = libnanomsg::EAGAIN           as isize,
+    BadFileDescriptor          = libnanomsg::EBADF            as isize,
+    InvalidArgument            = libnanomsg::EINVAL           as isize,
+    TooManyOpenFiles           = libnanomsg::EMFILE           as isize,
+    BadAddress                 = libnanomsg::EFAULT           as isize,
+    PermisionDenied            = libnanomsg::EACCESS          as isize,
+    NetworkReset               = libnanomsg::ENETRESET        as isize,
+    NetworkUnreachable         = libnanomsg::ENETUNREACH      as isize,
+    HostUnreachable            = libnanomsg::EHOSTUNREACH     as isize,
+    NotConnected               = libnanomsg::ENOTCONN         as isize,
+    MessageTooLong             = libnanomsg::EMSGSIZE         as isize,
+    Timeout                    = libnanomsg::ETIMEDOUT        as isize,
+    ConnectionAbort            = libnanomsg::ECONNABORTED     as isize,
+    ConnectionReset            = libnanomsg::ECONNRESET       as isize,
+    ProtocolNotAvailable       = libnanomsg::ENOPROTOOPT      as isize,
+    AlreadyConnected           = libnanomsg::EISCONN          as isize,
+    SocketTypeNotSupported     = libnanomsg::ESOCKTNOSUPPORT  as isize,
+    Terminating                = libnanomsg::ETERM            as isize,
+    NameTooLong                = libnanomsg::ENAMETOOLONG     as isize,
+    NoDevice                   = libnanomsg::ENODEV           as isize,
+    FileStateMismatch          = libnanomsg::EFSM             as isize,
+    Interrupted                = libnanomsg::EINTR            as isize
 }
 
 #[derive(PartialEq, Copy)]
@@ -69,51 +67,44 @@ impl NanoError {
 
     #[unstable]
     pub fn from_nn_errno(nn_errno: libc::c_int) -> NanoError {
-        let maybe_error_kind = FromPrimitive::from_i64(nn_errno as i64);
+        let maybe_error_kind = FromPrimitive::from_int(nn_errno as isize);
         let error_kind = maybe_error_kind.unwrap_or(Unknown);
 
         unsafe {
-            let c_desc: *const libc::c_char = libnanomsg::nn_strerror(nn_errno);
-            let c_desc_ref: &'static *const libc::c_char = transmute(&c_desc);
-            let desc_bytes = c_str_to_bytes(c_desc_ref);
-            let desc = str::from_utf8(desc_bytes).unwrap_or("Error");
+            let c_ptr: *const libc::c_char = libnanomsg::nn_strerror(nn_errno);
+            let c_str = CStr::from_ptr(c_ptr);
+            let bytes = c_str.to_bytes();
+            let desc = str::from_utf8(bytes).unwrap_or("Error");
 
             NanoError::new(desc, error_kind)
         }
     }
+}
 
-    #[unstable]
-    pub fn to_ioerror(&self) -> IoError {
-        match self.kind {
-            NanoErrorKind::Timeout => old_io::standard_error(IoErrorKind::TimedOut),
-            NanoErrorKind::InvalidArgument => old_io::standard_error(IoErrorKind::InvalidInput),
-            NanoErrorKind::BadFileDescriptor => old_io::standard_error(IoErrorKind::FileNotFound),
-            NanoErrorKind::OperationNotSupported => old_io::standard_error(IoErrorKind::MismatchedFileTypeForOperation),
-            NanoErrorKind::FileStateMismatch => old_io::standard_error(IoErrorKind::ResourceUnavailable),
-            NanoErrorKind::Terminating => old_io::standard_error(IoErrorKind::IoUnavailable),
-            NanoErrorKind::Interrupted => old_io::standard_error(IoErrorKind::BrokenPipe),
-            _ => {
-                IoError {
-                    kind: IoErrorKind::OtherIoError,
-                    desc: self.description,
-                    detail: None
-                }
-            }
+impl FromError<io::Error> for NanoError {
+    fn from_error(err: io::Error) -> NanoError {
+        match err.kind() {
+            io::ErrorKind::TimedOut                       => NanoError::from_nn_errno(libnanomsg::ETIMEDOUT),
+            io::ErrorKind::InvalidInput                   => NanoError::from_nn_errno(libnanomsg::EINVAL),
+            io::ErrorKind::FileNotFound                   => NanoError::from_nn_errno(libnanomsg::EBADF),
+            io::ErrorKind::MismatchedFileTypeForOperation => NanoError::from_nn_errno(libnanomsg::ENOTSUP),
+            io::ErrorKind::ResourceUnavailable            => NanoError::from_nn_errno(libnanomsg::EFSM),
+            io::ErrorKind::Interrupted                    => NanoError::from_nn_errno(libnanomsg::EINTR),
+            _                                             => NanoError::new("Other", Unknown)
         }
     }
 }
 
-impl FromError<old_io::IoError> for NanoError {
-    fn from_error(io_err: old_io::IoError) -> NanoError {
-        match io_err.kind {
-            IoErrorKind::TimedOut => NanoError::new(io_err.desc, NanoErrorKind::Timeout),
-            IoErrorKind::InvalidInput => NanoError::new(io_err.desc, NanoErrorKind::InvalidArgument),
-            IoErrorKind::FileNotFound => NanoError::new(io_err.desc, NanoErrorKind::BadFileDescriptor),
-            IoErrorKind::MismatchedFileTypeForOperation => NanoError::new(io_err.desc, NanoErrorKind::OperationNotSupported),
-            IoErrorKind::ResourceUnavailable => NanoError::new(io_err.desc, NanoErrorKind::FileStateMismatch),
-            IoErrorKind::IoUnavailable => NanoError::new(io_err.desc, NanoErrorKind::Terminating),
-            IoErrorKind::BrokenPipe => NanoError::new(io_err.desc, NanoErrorKind::Interrupted),
-            _ => NanoError::new(io_err.desc, Unknown)
+impl FromError<NanoError> for io::Error {
+    fn from_error(err: NanoError) -> io::Error {
+        match err.kind {
+            NanoErrorKind::Timeout                => io::Error::new(io::ErrorKind::TimedOut,                       err.description, None ),
+            NanoErrorKind::InvalidArgument        => io::Error::new(io::ErrorKind::InvalidInput,                   err.description, None ),
+            NanoErrorKind::BadFileDescriptor      => io::Error::new(io::ErrorKind::FileNotFound,                   err.description, None ),
+            NanoErrorKind::OperationNotSupported  => io::Error::new(io::ErrorKind::MismatchedFileTypeForOperation, err.description, None ),
+            NanoErrorKind::FileStateMismatch      => io::Error::new(io::ErrorKind::ResourceUnavailable,            err.description, None ),
+            NanoErrorKind::Interrupted            => io::Error::new(io::ErrorKind::Interrupted,                    err.description, None ),
+            _                                     => io::Error::new(io::ErrorKind::Other,                          err.description, None )
         }
     }
 }
@@ -143,8 +134,7 @@ mod tests {
     use super::NanoErrorKind::*;
     use super::NanoErrorKind;
     use super::NanoError;
-    use std::old_io;
-    use std::old_io::{IoErrorKind};
+    use std::io;
     use std::error::FromError;
     use std::num::FromPrimitive;
 
@@ -166,27 +156,26 @@ mod tests {
         assert_convert_error_code_to_error_kind(libnanomsg::EHOSTUNREACH, HostUnreachable);
     }
 
-    fn check_error_kind_match(nano_err_kind: NanoErrorKind, io_err_kind: IoErrorKind) {
+    fn check_error_kind_match(nano_err_kind: NanoErrorKind, io_err_kind: io::ErrorKind) {
         let nano_err = NanoError::from_nn_errno(nano_err_kind as libc::c_int);
-        let io_err = nano_err.to_ioerror();
+        let io_err: io::Error = FromError::from_error(nano_err);
 
-        assert_eq!(io_err_kind, io_err.kind)
+        assert_eq!(io_err_kind, io_err.kind())
     }
 
     #[test]
     fn check_to_ioerror() {
-        check_error_kind_match(NanoErrorKind::Timeout, IoErrorKind::TimedOut);
-        check_error_kind_match(NanoErrorKind::InvalidArgument, IoErrorKind::InvalidInput);
-        check_error_kind_match(NanoErrorKind::BadFileDescriptor, IoErrorKind::FileNotFound);
-        check_error_kind_match(NanoErrorKind::OperationNotSupported, IoErrorKind::MismatchedFileTypeForOperation);
-        check_error_kind_match(NanoErrorKind::FileStateMismatch, IoErrorKind::ResourceUnavailable);
-        check_error_kind_match(NanoErrorKind::Terminating, IoErrorKind::IoUnavailable);
-        check_error_kind_match(NanoErrorKind::Interrupted, IoErrorKind::BrokenPipe);
+        check_error_kind_match(NanoErrorKind::Timeout, io::ErrorKind::TimedOut);
+        check_error_kind_match(NanoErrorKind::InvalidArgument, io::ErrorKind::InvalidInput);
+        check_error_kind_match(NanoErrorKind::BadFileDescriptor, io::ErrorKind::FileNotFound);
+        check_error_kind_match(NanoErrorKind::OperationNotSupported, io::ErrorKind::MismatchedFileTypeForOperation);
+        check_error_kind_match(NanoErrorKind::FileStateMismatch, io::ErrorKind::ResourceUnavailable);
+        check_error_kind_match(NanoErrorKind::Interrupted, io::ErrorKind::Interrupted);
     }
 
     #[test]
     fn nano_err_can_be_converted_from_io_err() {
-        let io_err = old_io::standard_error(IoErrorKind::TimedOut);
+        let io_err = io::Error::new(io::ErrorKind::TimedOut, "Timed out", None);
         let nano_err: NanoError = FromError::from_error(io_err);
 
         assert_eq!(NanoErrorKind::Timeout, nano_err.kind)


### PR DESCRIPTION
 - Moves back from `old_io` to `io`.
 - Updates `read` and `write` variants to match the updated io package design.
 - Reformats constant declarations.