### PR TITLE
Update for rustup

### DIFF
--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,4 +1,4 @@
-#![feature(core, std_misc, io, old_io, env)]
+#![feature(core, std_misc, old_io)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;

--- a/examples/reqrep.rs
+++ b/examples/reqrep.rs
@@ -1,4 +1,4 @@
-#![feature(core, std_misc, io, old_io, env)]
+#![feature(core, std_misc, old_io)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;

--- a/src/result.rs
+++ b/src/result.rs
@@ -67,7 +67,7 @@ impl NanoError {
 
     #[unstable]
     pub fn from_nn_errno(nn_errno: libc::c_int) -> NanoError {
-        let maybe_error_kind = FromPrimitive::from_int(nn_errno as isize);
+        let maybe_error_kind = FromPrimitive::from_isize(nn_errno as isize);
         let error_kind = maybe_error_kind.unwrap_or(Unknown);
 
         unsafe {


### PR DESCRIPTION
Return type for `read_to_end` and `read_to_string` now includes length of read bytes.

I _think_ this is correct but I'm also not familiar with the internals.

`rustc 1.0.0-nightly (3e4be02b8 2015-03-13) (built 2015-03-13)`