### PR TITLE
Fixes range notation: use ( .. ) instead of range(,)

### DIFF
--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -15,7 +15,7 @@ const SERVER_DEVICE_URL: &'static str = "ipc:///tmp/pubsub_example_back.ipc";
 
 fn client(topic: &str) {
     let mut socket = Socket::new(Protocol::Sub).unwrap();
-    let mut setopt = socket.subscribe(topic);
+    let setopt = socket.subscribe(topic);
     let mut endpoint = socket.connect(CLIENT_DEVICE_URL).unwrap();
 
     match setopt {
@@ -46,7 +46,6 @@ fn server(topic: &str) {
     let mut count = 1u32;
 
     let sleep_duration = Duration::milliseconds(400);
-    let mut request = String::new();
 
     println!("Server is ready.");
 
@@ -70,7 +69,7 @@ fn device(topic: &str) {
     let mut front_socket = Socket::new_for_device(Protocol::Pub).unwrap();
     let mut front_endpoint = front_socket.bind(CLIENT_DEVICE_URL).unwrap();
     let mut back_socket = Socket::new_for_device(Protocol::Sub).unwrap();
-    let mut setopt = back_socket.subscribe(topic);
+    let setopt = back_socket.subscribe(topic);
     let mut back_endpoint = back_socket.bind(SERVER_DEVICE_URL).unwrap();
 
     match setopt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl<'a> PollRequest<'a> {
 
     fn copy_poll_result(&mut self) {
 
-        for x in range(0, self.fds.len()) {
+        for x in (0..self.fds.len()) {
             self.fds[x].check_pollin_result = self.nn_fds[x].pollin_result();
             self.fds[x].check_pollout_result = self.nn_fds[x].pollout_result();
         }
@@ -1270,7 +1270,7 @@ mod tests {
 
     fn test_zc_write(socket: &mut Socket, buf: &[u8]) {
         let mut msg = Socket::allocate_msg(buf.len()).unwrap();
-        for i in range(0, buf.len()) {
+        for i in (0..buf.len()) {
            msg[i] = buf[i]; 
         }
         match socket.zc_write(msg) {


### PR DESCRIPTION
 - Fixes range notation: use `(x..y)` notation instead of `range(x, y)`
 - Fixes minor warnings in the examples.