### PR TITLE
Fixes build against rust nightly (built 2015-04-02)

### DIFF
--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,11 +1,9 @@
-#![feature(std_misc, thread_sleep, convert)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;
 
 use nanomsg::{Socket, Protocol};
 
-use std::time::duration;
 use std::thread;
 use std::string::String;
 
@@ -36,13 +34,12 @@ fn worker() {
     input.connect("ipc:///tmp/pipeline_worker.ipc");
     output.connect("ipc:///tmp/pipeline_collector.ipc");
 
-    let sleep_duration = duration::Duration::milliseconds(300);
-
     loop {
         match input.read_to_string(&mut msg) {
             Ok(_) => {
                 println!("Worker received '{}'.", msg);
-                thread::sleep(sleep_duration); // fake some work ...
+
+                thread::sleep_ms(300); // fake some work ...
                 output.write_all(msg.as_bytes());
                 msg.clear();
             },
@@ -57,7 +54,6 @@ fn worker() {
 fn feeder() {
     let mut socket = Socket::new(Protocol::Push).unwrap();
     let mut endpoint = socket.bind("ipc:///tmp/pipeline_worker.ipc").unwrap();
-    let sleep_duration = duration::Duration::milliseconds(100);
     let mut count = 1u32;
 
     loop {
@@ -65,7 +61,7 @@ fn feeder() {
         let msg_bytes = msg.as_bytes();
         match socket.write_all(msg_bytes) {
             Ok(_) => {
-                thread::sleep(sleep_duration);
+                thread::sleep_ms(100);
                 count += 1;
             }
             Err(err) => {

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,11 +1,9 @@
-#![feature(std_misc, thread_sleep, convert)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;
 
 use nanomsg::{Socket, Protocol};
 
-use std::time::duration;
 use std::thread;
 
 use std::io::{Read, Write};
@@ -45,8 +43,6 @@ fn server(topic: &str) {
     let mut endpoint = socket.connect(SERVER_DEVICE_URL).unwrap();
     let mut count = 1u32;
 
-    let sleep_duration = duration::Duration::milliseconds(400);
-
     println!("Server is ready.");
 
     loop {
@@ -58,7 +54,7 @@ fn server(topic: &str) {
                 break
             }
         }
-        thread::sleep(sleep_duration);
+        thread::sleep_ms(400);
         count += 1;
     }
 

--- a/examples/reqrep.rs
+++ b/examples/reqrep.rs
@@ -1,11 +1,9 @@
-#![feature(std_misc, thread_sleep, convert)]
 #![allow(unused_must_use)]
 
 extern crate nanomsg;
 
 use nanomsg::{Socket, Protocol};
 
-use std::time::duration;
 use std::thread;
 
 use std::io::{Read, Write};
@@ -18,7 +16,6 @@ fn client() {
     let mut endpoint = socket.connect(CLIENT_DEVICE_URL).unwrap();
     let mut count = 1u32;
 
-    let sleep_duration = duration::Duration::milliseconds(100);
     let mut reply = String::new();
 
     loop {
@@ -42,7 +39,7 @@ fn client() {
                 break
             }
         }
-        thread::sleep(sleep_duration);
+        thread::sleep_ms(100);
         count += 1;
     }
 
@@ -54,7 +51,6 @@ fn server() {
     let mut endpoint = socket.connect(SERVER_DEVICE_URL).unwrap();
     let mut count = 1u32;
 
-    let sleep_duration = duration::Duration::milliseconds(400);
     let mut request = String::new();
 
     println!("Server is ready.");
@@ -74,7 +70,7 @@ fn server() {
                     }
                 }
                 request.clear();
-                thread::sleep(sleep_duration);
+                thread::sleep_ms(400);
                 count += 1;
             },
             Err(err) => {

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(libc, std_misc, thread_sleep)]
+#![feature(libc)]
 #![allow(non_camel_case_types)]
 #[link(name = "nanomsg", kind = "static")]
 
@@ -298,8 +298,6 @@ mod tests {
     use std::ptr;
     use std::mem::transmute;
 
-    use std::time::duration;
-
     use std::sync::{Arc, Barrier};
     use std::thread;
 
@@ -343,10 +341,6 @@ mod tests {
         let topic_ptr = topic.as_ptr();
         let topic_raw_ptr = topic_ptr as *const c_void;
         assert!(unsafe { nn_setsockopt (socket, NN_SUB, NN_SUB_SUBSCRIBE, topic_raw_ptr, topic_len) } >= 0);
-    }
-
-    fn sleep_some_millis(timeout: i64) {
-        thread::sleep(duration::Duration::milliseconds(timeout));
     }
 
     /// This ensures that the one-way pipe works correctly and also serves as an example
@@ -416,7 +410,7 @@ mod tests {
         let sock3 = test_create_socket(AF_SP, NN_BUS);
         let sock3_read_endpoint = test_connect(sock3, url.as_ptr() as *const i8);
 
-        sleep_some_millis(10);
+        thread::sleep_ms(10);
 
         let msg = "foobar";
         test_send(sock1, msg);
@@ -451,7 +445,7 @@ mod tests {
         let topic2 = "bar";
         test_subscribe(sub_sock2, topic2);
 
-        sleep_some_millis(10);
+        thread::sleep_ms(10);
 
         let msg1 = "foobar";
         test_send(pub_sock, msg1);
@@ -485,7 +479,7 @@ mod tests {
         let resp_sock2 = test_create_socket(AF_SP, NN_RESPONDENT);
         let resp_endpoint2 = test_connect(resp_sock2, url.as_ptr() as *const i8);
 
-        sleep_some_millis(10);
+        thread::sleep_ms(10);
 
         let survey = "are_you_there";
         test_send(surv_sock, survey);
@@ -527,7 +521,7 @@ mod tests {
 
         test_bind(s1, url.as_ptr() as *const i8);
         test_connect(s2, url.as_ptr() as *const i8);
-        sleep_some_millis(10);
+        thread::sleep_ms(10);
 
         let poll_result2 = unsafe { nn_poll(fd_ptr, 2, 10) as usize };
         assert_eq!(2, poll_result2);
@@ -536,7 +530,7 @@ mod tests {
 
         let msg = "foobar";
         test_send(s2, msg);
-        sleep_some_millis(10);
+        thread::sleep_ms(10);
 
         let poll_result3 = unsafe { nn_poll(fd_ptr, 2, 10) as usize };
         assert_eq!(2, poll_result3);


### PR DESCRIPTION
 - Replaces calls to `thread::sleep` by `thread::sleep_ms`
 - Replaces `std::error::FromError` by `std::convert::From`