### PR TITLE
Fixes build against rustc 1.0.0-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-
+rust: 1.0.0-beta
 env:
   global:
     - secure: "hdvu4EPy8iJMrvACGQNsHcBaAnRYp8NbxH6a+Q/H4af2kRAgjqFLGU9PzSuFvx+YARgg0guX1y0lFle6+cvRGveB1qqAftEtuEjdYOhVvipgjY6SzyyJhfJYNNTYcvLyyzWWU6lSIWMysVdPPNdQywkjCXeiI/peLBHCrc1CMyQ="

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ license = "MIT"
 [dependencies.nanomsg-sys]
 path = "./nanomsg_sys"
 version = "0.1.2"
+
+[dependencies]
+libc = "0.1.5"

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -15,3 +15,6 @@ repository = "https://github.com/thehydroimpulse/nanomsg.rs"
 keywords = ["binding", "nanomsg"]
 links = "nanomsg"
 build = "build.rs"
+
+[dependencies]
+libc = "0.1.5"

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(libc, negate_unsigned)]
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, non_snake_case)]
 #[link(name = "nanomsg", kind = "static")]
 
 extern crate libc;
@@ -12,7 +11,10 @@ pub const AF_SP_RAW: c_int = 2;
 pub const NN_PROTO_PIPELINE: c_int = 5;
 pub const NN_PUSH: c_int = NN_PROTO_PIPELINE * 16 + 0;
 pub const NN_PULL: c_int = NN_PROTO_PIPELINE * 16 + 1;
-pub const NN_MSG: size_t = -1;
+//pub const NN_MSG: size_t = -1;
+pub fn NN_MSG() -> size_t {
+    size_t::max_value()
+}
 pub const NN_PROTO_REQREP: c_int = 3;
 pub const NN_REQ: c_int = NN_PROTO_REQREP * 16 + 0;
 pub const NN_REP: c_int = NN_PROTO_REQREP * 16 + 1;
@@ -329,7 +331,7 @@ mod tests {
 
     fn test_receive(socket: c_int, expected: &str) {
         let mut buf: *mut u8 = ptr::null_mut();
-        let bytes = unsafe { nn_recv(socket, transmute(&mut buf), NN_MSG, 0) };
+        let bytes = unsafe { nn_recv(socket, transmute(&mut buf), NN_MSG(), 0) };
         assert!(bytes >= 0);
         let msg = unsafe { slice::from_raw_parts_mut(buf, bytes as usize) };
         assert_eq!(msg, expected.as_bytes());

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,25 +1,19 @@
 use libc::c_int;
 use nanomsg_sys;
-use result::{NanoResult,last_nano_error};
-use std::marker::NoCopy;
+use result::{Result,last_nano_error};
 
 /// An endpoint created for a specific socket. Each endpoint is identified
 /// by a unique return value that can be further passed to a shutdown
 /// function. The shutdown is done through the endpoint itself and not the Socket
 pub struct Endpoint {
     value: c_int,
-    socket: c_int,
-    no_copy_marker: NoCopy
+    socket: c_int
 }
 
 impl Endpoint {
     #[unstable]
     pub fn new(value: c_int, socket: c_int) -> Endpoint {
-        Endpoint {
-            value: value,
-            socket: socket,
-            no_copy_marker: NoCopy
-        }
+        Endpoint { value: value, socket: socket }
     }
 
     /// Removes an endpoint from the socket that created it (via `bind` or `connect`).
@@ -27,8 +21,7 @@ impl Endpoint {
     /// the library will try to deliver any outstanding outbound messages to the endpoint 
     /// for the time specified by `Socket::set_linger`.
     #[unstable]
-    pub fn shutdown(&mut self) -> NanoResult<()> {
-
+    pub fn shutdown(&mut self) -> Result<()> {
         let ret = unsafe { nanomsg_sys::nn_shutdown(self.socket, self.value) };
 
         if ret == -1 {


### PR DESCRIPTION
 - Makes use of libc from crates.io
 - Replaces NanoError by an Error enum with std:error::Error trait
 - Renames NanoError to Error
 - Replaces all calls to thread::sleep(&Duration) by thread::sleep_ms(u32)
 - Removes the uses of NoCopy marker