### PR TITLE
Fixes NN_MSG constant definition

### DIFF
--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate libc;
 
 use libc::{c_int, c_void, size_t, c_char, c_short};
+
 pub use posix_consts::*;
 
 pub const AF_SP: c_int = 1;
@@ -11,10 +12,7 @@ pub const AF_SP_RAW: c_int = 2;
 pub const NN_PROTO_PIPELINE: c_int = 5;
 pub const NN_PUSH: c_int = NN_PROTO_PIPELINE * 16 + 0;
 pub const NN_PULL: c_int = NN_PROTO_PIPELINE * 16 + 1;
-//pub const NN_MSG: size_t = -1;
-pub fn NN_MSG() -> size_t {
-    size_t::max_value()
-}
+pub const NN_MSG: size_t = std::usize::MAX as size_t;
 pub const NN_PROTO_REQREP: c_int = 3;
 pub const NN_REQ: c_int = NN_PROTO_REQREP * 16 + 0;
 pub const NN_REP: c_int = NN_PROTO_REQREP * 16 + 1;
@@ -331,7 +329,7 @@ mod tests {
 
     fn test_receive(socket: c_int, expected: &str) {
         let mut buf: *mut u8 = ptr::null_mut();
-        let bytes = unsafe { nn_recv(socket, transmute(&mut buf), NN_MSG(), 0) };
+        let bytes = unsafe { nn_recv(socket, transmute(&mut buf), NN_MSG, 0) };
         assert!(bytes >= 0);
         let msg = unsafe { slice::from_raw_parts_mut(buf, bytes as usize) };
         assert_eq!(msg, expected.as_bytes());


### PR DESCRIPTION
 - Makes NN_MSG a constant back from a function (!?).
 - Uses `Vec::extend` instead of copying manually the content of the read msg in `read_to_end`.