### PR TITLE
Fixes build against rustc 1.0.0-beta.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: 1.0.0-beta
+rust: 1.0.0-beta.2
 env:
   global:
     - secure: "hdvu4EPy8iJMrvACGQNsHcBaAnRYp8NbxH6a+Q/H4af2kRAgjqFLGU9PzSuFvx+YARgg0guX1y0lFle6+cvRGveB1qqAftEtuEjdYOhVvipgjY6SzyyJhfJYNNTYcvLyyzWWU6lSIWMysVdPPNdQywkjCXeiI/peLBHCrc1CMyQ="

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ path = "./nanomsg_sys"
 version = "0.1.3"
 
 [dependencies]
-libc = "0.1.5"
+libc = "0.1.6"

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -17,4 +17,4 @@ links = "nanomsg"
 build = "build.rs"
 
 [dependencies]
-libc = "0.1.5"
+libc = "0.1.6"

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -560,7 +560,7 @@ mod tests {
         let drop_after_use_pull = drop_after_use.clone();
         let drop_after_use_push = drop_after_use.clone();
 
-        let push_thread = thread::scoped(move || {
+        let push_thread = thread::spawn(move || {
             let push_msg = "foobar";
             let push_sock = test_create_socket(AF_SP, NN_PUSH);
             let push_endpoint = test_bind(push_sock, url.as_ptr() as *const i8);
@@ -570,7 +570,7 @@ mod tests {
             finish_child_task(drop_after_use_push, push_sock, push_endpoint);
         });
 
-        let pull_thread = thread::scoped(move || {
+        let pull_thread = thread::spawn(move || {
             let pull_msg = "foobar";
             let pull_sock = test_create_socket(AF_SP, NN_PULL);
             let pull_endpoint = test_connect(pull_sock, url.as_ptr() as *const i8);
@@ -580,8 +580,8 @@ mod tests {
             finish_child_task(drop_after_use_pull, pull_sock, pull_endpoint);
         });
 
-        push_thread.join();
-        pull_thread.join();
+        push_thread.join().unwrap();
+        pull_thread.join().unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1335,7 +1335,7 @@ mod tests {
         let finish_line_pull = finish_line.clone();
         let finish_line_push = finish_line.clone();
 
-        let push_thread = thread::scoped(move || {
+        let push_thread = thread::spawn(move || {
             let mut push_socket = test_create_socket(Push);
             
             test_bind(&mut push_socket, url);
@@ -1344,7 +1344,7 @@ mod tests {
             finish_line_push.wait();
         });
 
-        let pull_thread = thread::scoped(move|| {
+        let pull_thread = thread::spawn(move|| {
             let mut pull_socket = test_create_socket(Pull);
 
             test_connect(&mut pull_socket, url);


### PR DESCRIPTION
 - Uses `thread::spawn` instead of the now deprecated `thread::scoped`
 - Upgrades libc to 0.1.6