### PR TITLE
Add Windows CI And Fix Some Tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+os:
+  - MinGW
+
+install:
+  - cd ..
+  # Download And Compile nanomsg
+  - ps: Start-FileDownload 'http://download.nanomsg.org/nanomsg-0.5-beta.zip'
+  - 7z x nanomsg-0.5-beta.zip
+  - cd nanomsg-0.5-beta
+  - cmake . && msbuild nanomsg.sln
+  # Fix nanomsg Library Directory
+  - mv .\Debug .\.libs
+  # Return To Git Directory
+  - cd ..\nanomsg-rs
+  # Download And Install Rust
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
+  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Rust"
+  - SET PATH=%PATH%;C:\MinGW\bin
+  - SET PATH=%PATH%;C:\Rust\bin
+  - gcc -v
+  - rustc -V
+  - cargo -V
+
+build_script:
+  - cargo build
+
+test_script:
+  - cargo test

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -112,7 +112,7 @@ mod posix_consts {
     pub const ENOTSOCK: c_int = NN_HAUSNUMERO + 9;
     pub const EAFNOSUPPORT: c_int = NN_HAUSNUMERO + 10;
     pub const EPROTO : c_int = NN_HAUSNUMERO + 11;
-    pub const EAGAIN: c_int = NN_HAUSNUMERO + 12;
+    pub const EAGAIN: c_int = 11;
     pub const EBADF: c_int = NN_HAUSNUMERO + 13;
     pub const EINVAL: c_int = NN_HAUSNUMERO + 14;
     pub const EMFILE: c_int = NN_HAUSNUMERO + 15;

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -95,6 +95,10 @@ mod posix_consts {
 mod posix_consts {
     use libc::c_int;
 
+    pub const ENAMETOOLONG: c_int = 38;
+    pub const ENODEV: c_int = 19;
+    pub const EINTR: c_int = 4;
+    
     pub const NN_HAUSNUMERO: c_int = 156384712;
 
     pub const ENOTSUP : c_int = NN_HAUSNUMERO + 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1400,7 +1400,7 @@ mod tests {
         test_subscribe(&mut sock3, "bar");
         test_connect(&mut sock3, url);
 
-        thread::sleep_ms(10);
+        thread::sleep_ms(100);
 
         let msg1 = b"foobar";
         test_write(&mut sock1, msg1);


### PR DESCRIPTION
I plan on using this library on Windows very soon and I figured I would submit a pull request for changes that I have had to do to make the crate compile, as well as pass all tests on Windows. I have also gone ahead and setup an ```appveyor.yml``` file which will let you run Windows continuous integration on Appveyor (all you have to do is sign in with github and flip a switch).

In regards to the changes I had to make in nanomsg_sys, the three constants I added at the top were not defined for Windows and I saw that the actual nanomsg library actually grabs them from ```errno.h```. So I went ahead and added the constants that can be found in the Windows ```errno.h``` file.

I also saw all lot of the constants for Windows followed the form ```NN_HAUSNUMERO + n```. I am almost sure this is incorrect as the nanomsg library says that those constants are not defined for some non-posix compliant systems, but I saw most (if not all) of them in ```errno.h``` on Windows. I only changed ```EAGAIN``` as that constant was the only one causing some tests to fail (see [this Appveyor build](https://ci.appveyor.com/project/GGist/nanomsg-rs/build/1.0.1)).

Lastly, in ```tests::pubsub()``` it looks like Appveyor was not able to subscribe and connect to both sockets in under 10 ms as a [previous build](https://ci.appveyor.com/project/GGist/nanomsg-rs/build/1.0.2) I attempted ended up blocking. I changed it to 100 ms and [it went through fine](https://ci.appveyor.com/project/GGist/nanomsg-rs/build/1.0.3), although I suspect doing stuff like this might be a bit flaky.