### PR TITLE
Have Appveyor run nanomsg_sys tests; Fix nanomsg_sys tests on Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,27 +2,31 @@ os:
   - MinGW
 
 install:
+  # Go To libnanomsg Destination Directory
   - cd ..
-  # Download And Compile nanomsg
+  # Download And Compile libnanomsg
   - ps: Start-FileDownload 'http://download.nanomsg.org/nanomsg-0.5-beta.zip'
   - 7z x nanomsg-0.5-beta.zip
   - cd nanomsg-0.5-beta
   - cmake . && msbuild nanomsg.sln
-  # Fix nanomsg Library Directory
+  # Fix libnanomsg Library Directory Name
   - mv .\Debug .\.libs
-  # Return To Git Directory
+  # Return To nanomsg-rs Git Directory
   - cd ..\nanomsg-rs
   # Download And Install Rust
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
-  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Rust"
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.0.0-i686-pc-windows-gnu.msi'
+  - msiexec /i rust-1.0.0-i686-pc-windows-gnu.msi /passive /norestart
   - SET PATH=%PATH%;C:\MinGW\bin
-  - SET PATH=%PATH%;C:\Rust\bin
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust stable 1.0\bin
   - gcc -v
   - rustc -V
   - cargo -V
 
 build_script:
   - cargo build
-
+ 
 test_script:
+  - cargo test
+  # Move libnanomsg To Test nanomsg_sys
+  - mv ../nanomsg-0.5-beta ./nanomsg-0.5-beta && cd nanomsg_sys
   - cargo test

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -94,41 +94,41 @@ mod posix_consts {
 #[cfg(windows)]
 mod posix_consts {
     use libc::c_int;
-
-    pub const ENAMETOOLONG: c_int = 38;
-    pub const ENODEV: c_int = 19;
-    pub const EINTR: c_int = 4;
     
     pub const NN_HAUSNUMERO: c_int = 156384712;
 
-    pub const ENOTSUP : c_int = NN_HAUSNUMERO + 1;
-    pub const EPROTONOSUPPORT: c_int = NN_HAUSNUMERO + 2;
-    pub const ENOBUFS: c_int = NN_HAUSNUMERO + 3;
-    pub const ENETDOWN: c_int = NN_HAUSNUMERO + 4;
-    pub const EADDRINUSE: c_int = NN_HAUSNUMERO + 5;
-    pub const EADDRNOTAVAIL: c_int = NN_HAUSNUMERO + 6;
-    pub const ECONNREFUSED: c_int = NN_HAUSNUMERO + 7;
-    pub const EINPROGRESS: c_int = NN_HAUSNUMERO + 8;
-    pub const ENOTSOCK: c_int = NN_HAUSNUMERO + 9;
-    pub const EAFNOSUPPORT: c_int = NN_HAUSNUMERO + 10;
-    pub const EPROTO : c_int = NN_HAUSNUMERO + 11;
-    pub const EAGAIN: c_int = 11;
-    pub const EBADF: c_int = NN_HAUSNUMERO + 13;
-    pub const EINVAL: c_int = NN_HAUSNUMERO + 14;
-    pub const EMFILE: c_int = NN_HAUSNUMERO + 15;
-    pub const EFAULT: c_int = NN_HAUSNUMERO + 16;
-    pub const EACCESS: c_int = NN_HAUSNUMERO + 17;
-    pub const ENETRESET: c_int = NN_HAUSNUMERO + 18;
-    pub const ENETUNREACH: c_int = NN_HAUSNUMERO + 19;
-    pub const EHOSTUNREACH: c_int = NN_HAUSNUMERO + 20;
-    pub const ENOTCONN: c_int = NN_HAUSNUMERO + 21;
-    pub const EMSGSIZE: c_int = NN_HAUSNUMERO + 22;
-    pub const ETIMEDOUT: c_int = NN_HAUSNUMERO + 23;
-    pub const ECONNABORTED: c_int = NN_HAUSNUMERO + 24;
-    pub const ECONNRESET: c_int = NN_HAUSNUMERO + 25;
-    pub const ENOPROTOOPT: c_int = NN_HAUSNUMERO + 26;
-    pub const EISCONN: c_int = NN_HAUSNUMERO + 27;
+    pub const ENOTSUP:         c_int = NN_HAUSNUMERO + 1;
+    pub const EPROTO:          c_int = NN_HAUSNUMERO + 11;
+    pub const EACCESS:         c_int = NN_HAUSNUMERO + 17;
+    pub const EISCONN:         c_int = NN_HAUSNUMERO + 27;
     pub const ESOCKTNOSUPPORT: c_int = NN_HAUSNUMERO + 28;
+    
+    pub const EINTR:           c_int = 4;
+    pub const EBADF:           c_int = 9;
+    pub const EAGAIN:          c_int = 11;
+    pub const EFAULT:          c_int = 14;
+    pub const ENODEV:          c_int = 19;
+    pub const EINVAL:          c_int = 22;
+    pub const EMFILE:          c_int = 24;
+    pub const ENAMETOOLONG:    c_int = 38;
+    pub const EADDRINUSE:      c_int = 100;
+    pub const EADDRNOTAVAIL:   c_int = 101;
+    pub const EAFNOSUPPORT:    c_int = 102;
+    pub const ECONNABORTED:    c_int = 106;
+    pub const ECONNREFUSED:    c_int = 107;
+    pub const ECONNRESET:      c_int = 108;
+    pub const EHOSTUNREACH:    c_int = 110;
+    pub const EINPROGRESS:     c_int = 112;
+    pub const EMSGSIZE:        c_int = 115;
+    pub const ENETDOWN:        c_int = 116;
+    pub const ENETRESET:       c_int = 117;
+    pub const ENETUNREACH:     c_int = 118;
+    pub const ENOBUFS:         c_int = 119;
+    pub const ENOPROTOOPT:     c_int = 123;
+    pub const ENOTCONN:        c_int = 126;
+    pub const ENOTSOCK:        c_int = 128;
+    pub const EPROTONOSUPPORT: c_int = 135;
+    pub const ETIMEDOUT:       c_int = 138;
 }
 
 #[repr(C)]
@@ -453,7 +453,7 @@ mod tests {
         let topic2 = "bar";
         test_subscribe(sub_sock2, topic2);
 
-        thread::sleep_ms(10);
+        thread::sleep_ms(100);
 
         let msg1 = "foobar";
         test_send(pub_sock, msg1);


### PR DESCRIPTION
In reference to #132 and #133.

I realized that Appveyor was not running tests for nanomsg_sys so I have fixed that. The results from that commit [can be seen here](https://ci.appveyor.com/project/GGist/nanomsg-rs/build/1.0.1). You can see that ```tests::constants_should_match_return_of_symbol_func()``` failed and ```tests::should_create_a_pubsub()``` ended up blocking.

I fixed ```tests::should_create_a_pubsub()``` by increasing the sleep time and fixed ```tests::constants_should_match_return_of_symbol_func()``` by changing more Windows specific constants. The passing build can be found [here](https://ci.appveyor.com/project/GGist/nanomsg-rs/build/1.0.2).

@blabaere In regards to the comment left on my previous commit, my intuition when it comes to the differences between C runtimes is lacking. If I understand correctly, the constants can vary between operating systems and compilers? I know that in the two main compilers for Windows (gcc via mingw and msvc) both of the ```errno.h``` constants were identical. I can't speak for how they might vary in other circumstances.