### PR TITLE
Upgrade to nanomsg 0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ nanomsg-0.4-beta
 nanomsg-0.5-beta
 nanomsg-0.6-beta
 nanomsg-0.7-beta
+nanomsg-0.8-beta
+nanomsg-0.9-beta
 Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 install:
   - make deps
-  - pkg-config --static --libs nanomsg
+  - pkg-config --libs nanomsg
 
 script:
   - rustc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - stable
 env:
   global:
     - secure: "hdvu4EPy8iJMrvACGQNsHcBaAnRYp8NbxH6a+Q/H4af2kRAgjqFLGU9PzSuFvx+YARgg0guX1y0lFle6+cvRGveB1qqAftEtuEjdYOhVvipgjY6SzyyJhfJYNNTYcvLyyzWWU6lSIWMysVdPPNdQywkjCXeiI/peLBHCrc1CMyQ="

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 
 install:
   - make deps
+  - pkg-config --libs libnanomsg
 
 script:
   - rustc --version
@@ -19,3 +20,8 @@ after_success:
   - cp target/doc doc
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh 
+
+addons:
+  apt:
+    packages:
+      - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
 
 script:
   - rustc --version
-  - cargo test
   - cd nanomsg_sys && cargo test
+  - cargo test
   - cargo doc
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   - rustc --version
-  - cd nanomsg_sys && cargo test
+  - cd nanomsg_sys && cargo test && cd ..
   - cargo test
   - cargo doc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - stable
+  - nightly
 env:
   global:
     - secure: "hdvu4EPy8iJMrvACGQNsHcBaAnRYp8NbxH6a+Q/H4af2kRAgjqFLGU9PzSuFvx+YARgg0guX1y0lFle6+cvRGveB1qqAftEtuEjdYOhVvipgjY6SzyyJhfJYNNTYcvLyyzWWU6lSIWMysVdPPNdQywkjCXeiI/peLBHCrc1CMyQ="

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 install:
   - make deps
-  - pkg-config --libs libnanomsg
+  - pkg-config --static --libs nanomsg
 
 script:
   - rustc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pkg-config --libs nanomsg
 
 script:
-  - rustc --version
+  - rustc --version --verbose
   - cd nanomsg_sys && cargo test && cd ..
   - cargo test
   - cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanomsg"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   "Daniel Fagnan <dnfagnan@gmail.com>",
   "Jason E. Aten",
@@ -21,7 +21,7 @@ license = "MIT"
 
 [dependencies.nanomsg-sys]
 path = "./nanomsg_sys"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
-libc = "0.2.5"
+libc = "0.2.11"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 
 deps:
-	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
-	tar -xvzf 0.9-beta.tar.gz
-	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build .
-	cd nanomsg-0.9-beta/build && sudo cmake --build . --target install
+	wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz
+	tar -xvzf 1.0.0.tar.gz
+	cd nanomsg-1.0.0 && mkdir build && cd build && cmake .. && cmake --build .
+	cd nanomsg-1.0.0/build && sudo cmake --build . --target install
 
 clean:
 	rm -rf target
-	rm -rf nanomsg-0.9-beta
-	rm 0.9-beta.tar.gz
+	rm -rf nanomsg-1.0.0
+	rm 1.0.0.tar.gz
 
 .PHONY: clean deps

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
-	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake -DNN_STATIC_LIB:BOOL=ON --build .
-	cd nanomsg-0.9-beta/build && make && sudo make install
+	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build .
+	cd nanomsg-0.9-beta/build && cmake --build . --target install
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
 	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build .
-	cd nanomsg-0.9-beta/build && cmake --build . --target install
+	cd nanomsg-0.9-beta/build && sudo cmake --build . --target install
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 deps:
-	wget https://github.com/nanomsg/nanomsg/releases/download/0.8-beta/nanomsg-0.8-beta.tar.gz
-	tar -xvzf nanomsg-0.8-beta.tar.gz
-	cd nanomsg-0.8-beta && ./configure && make && sudo make install
-	sudo ldconfig
+	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
+	tar -xvzf 0.9-beta.tar.gz
+	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build . && ctest . 
 
 clean:
 	rm -rf target
-	rm -rf nanomsg-0.8-beta
-	rm nanomsg-0.8-beta.tar.gz
+	rm -rf nanomsg-0.9-beta
+	rm nanomsg-0.9-beta.tar.gz
 
 .PHONY: clean deps

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
-	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build .
+	cd nanomsg-0.9-beta && mkdir build && cd build && cmake -DNN_STATIC_LIB:BOOL=ON .. && cmake --build .
 	cd nanomsg-0.9-beta/build && sudo cmake --build . --target install
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
 	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build . && ctest . 
-	sudo cmake --build . --target install
+	cd nanomsg-0.9-beta/build && sudo cmake --build . --target install
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
 	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build . && ctest . 
+	sudo cmake --build . --target install
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
-	cd nanomsg-0.9-beta && mkdir build && cd build && cmake -DNN_STATIC_LIB:BOOL=ON .. && cmake --build .
+	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build .
 	cd nanomsg-0.9-beta/build && sudo cmake --build . --target install
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
+
 deps:
 	wget https://github.com/nanomsg/nanomsg/archive/0.9-beta.tar.gz 
 	tar -xvzf 0.9-beta.tar.gz
-	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake --build . && ctest . 
-	cd nanomsg-0.9-beta/build && sudo cmake --build . --target install
+	cd nanomsg-0.9-beta && mkdir build && cd build && cmake .. && cmake -DNN_STATIC_LIB:BOOL=ON --build .
+	cd nanomsg-0.9-beta/build && make && sudo make install
 
 clean:
 	rm -rf target
 	rm -rf nanomsg-0.9-beta
-	rm nanomsg-0.9-beta.tar.gz
+	rm 0.9-beta.tar.gz
 
 .PHONY: clean deps

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nanomsg 
 
-![Cargo 0.5.0](http://img.shields.io/badge/cargo-0.5.0-orange.svg?style=flat)
+![Cargo 0.6.0](http://img.shields.io/badge/cargo-0.6.0-orange.svg?style=flat)
 ![MIT License](http://img.shields.io/npm/l/express.svg?style=flat)
 [![Build Status](https://travis-ci.org/thehydroimpulse/nanomsg.rs.svg?branch=master)](https://travis-ci.org/thehydroimpulse/nanomsg.rs) 
 [![Build status](https://ci.appveyor.com/api/projects/status/hwfjigfwyomc56u1?svg=true)](https://ci.appveyor.com/project/thehydroimpulse/nanomsg-rs)
@@ -15,7 +15,7 @@ Nanomsg is a modern messaging library that is the successor to ZeroMQ, written i
 
 ### Requirements
 
-* Nanomsg 0.8.0
+* Nanomsg 0.9.0
 
 Installing nanomsg:
 
@@ -27,7 +27,7 @@ make deps
 
 ```toml
 [dependencies]
-nanomsg = "0.5.0"
+nanomsg = "0.6.0"
 ```
 
 Simply import the crate to use it:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Nanomsg is a modern messaging library that is the successor to ZeroMQ, written i
 
 ### Requirements
 
-* Nanomsg 0.9.0
+* Nanomsg 1.0.0
 
 Installing nanomsg:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,13 +13,6 @@ install:
   - cmake ..
   - cmake --build .
   - cmake --build . --target install
-  #- SET PATH=%PATH%;C:\MinGW\bin
-  #- echo Current dir is '%CD%'
-  #- dir . /s
-  #- mingw32-make.exe
-  #- mingw32-make.exe install
-  # Fix libnanomsg Library Directory Name
-  # - mv .\Debug .\.libs
   # Return To nanomsg-rs Git Directory
   - cd ../../nanomsg-rs
   # Download And Install Rust

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,15 +25,18 @@ install:
   # Download And Install Rust
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-x86_64-pc-windows-msvc.msi'
   - start /wait msiexec /i  rust-1.8.0-x86_64-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
-  - dir "C:\Program Files (x86)"
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - rustc -V
   - cargo -V
 
 build_script:
+  - set LIB=%LIB%;C:\Program Files (x86)\nanomsg\lib
+  - set PATH=%PATH%;C:\Program Files (x86)\nanomsg\bin
   - cargo build
  
 test_script:
+  - set LIB=%LIB%;C:\Program Files (x86)\nanomsg\lib
+  - set PATH=%PATH%;C:\Program Files (x86)\nanomsg\bin
   - cargo test
   # Move libnanomsg To Test nanomsg_sys
   - mv ..\nanomsg-0.9-beta .\nanomsg-0.9-beta && cd nanomsg_sys

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ install:
   - mkdir build
   - cd build
   - cmake ..
-  - cmake -DNN_STATIC_LIB:BOOL=ON --build .
-  - cmake -DNN_STATIC_LIB:BOOL=ON --build . --target install
+  - cmake --build .
+  - cmake --build . --target install
   #- SET PATH=%PATH%;C:\MinGW\bin
   #- echo Current dir is '%CD%'
   #- dir . /s

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ install:
   # Go To libnanomsg Destination Directory
   - cd ..
   # Download And Compile libnanomsg
-  - ps: Start-FileDownload 'https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz'
-  - 7z x 1.0.0.tar.gz
+  - ps: Start-FileDownload 'https://github.com/nanomsg/nanomsg/archive/1.0.0.zip'
+  - 7z x 1.0.0.zip
   - cd nanomsg-1.0.0
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-os:
-  - MinGW
+#os:
+#  - MinGW
 
 install:
   # Go To libnanomsg Destination Directory

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ install:
   # Return To nanomsg-rs Git Directory
   - cd ../../nanomsg-rs
   # Download And Install Rust
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-x86_64-pc-windows-msvc.msi'
-  - start /wait msiexec /i  rust-1.8.0-x86_64-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-i686-pc-windows-msvc.msi'
+  - start /wait msiexec /i  rust-1.8.0-i686-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - rustc -V
   - cargo -V

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
   - cd build
   - cmake ..
   - cmake -DNN_STATIC_LIB:BOOL=ON --build .
+  - SET PATH=%PATH%;C:\MinGW\bin
   - make
   - make install
   # Fix libnanomsg Library Directory Name

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ install:
   - cmake ..
   - cmake -DNN_STATIC_LIB:BOOL=ON --build .
   - SET PATH=%PATH%;C:\MinGW\bin
-  - make
-  - make install
+  - mingw32-make.exe
+  - mingw32-make.exe install
   # Fix libnanomsg Library Directory Name
   # - mv .\Debug .\.libs
   # Return To nanomsg-rs Git Directory

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-i686-pc-windows-msvc.msi'
   - start /wait msiexec /i  rust-1.8.0-i686-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - rustc -V
+  - rustc -V -v
   - cargo -V
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ install:
   - cmake -DNN_STATIC_LIB:BOOL=ON --build .
   - SET PATH=%PATH%;C:\MinGW\bin
   - echo Current dir is '%CD%'
+  - dir . /s
   - mingw32-make.exe
   - mingw32-make.exe install
   # Fix libnanomsg Library Directory Name

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,26 +7,26 @@ install:
   - cd nanomsg-1.0.0
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -G"Visual Studio 14 Win64" -DNN_ENABLE_DOC=OFF ..
   - cmake --build .
   - cmake --build . --target install
   # Return To nanomsg-rs Git Directory
   - cd ../../nanomsg-rs
   # Download And Install Rust
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.9.0-i686-pc-windows-msvc.msi'
-  - start /wait msiexec /i  rust-1.9.0-i686-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
-  - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.9.0-x86_64-pc-windows-msvc.msi'
+  - start /wait msiexec /i rust-1.9.0-x86_64-pc-windows-msvc.msi INSTALLDIR="C:\Program Files\Rust" /quiet /qn /passive /norestart
+  - set PATH=%PATH%;C:\Program Files\Rust\bin
   - rustc -V -v
   - cargo -V
 
 build_script:
-  - set LIB=%LIB%;C:\Program Files (x86)\nanomsg\lib
-  - set PATH=%PATH%;C:\Program Files (x86)\nanomsg\bin
+  - set LIB=%LIB%;C:\Program Files\nanomsg\lib
+  - set PATH=%PATH%;C:\Program Files\nanomsg\bin
   - cargo build
  
 test_script:
-  - set LIB=%LIB%;C:\Program Files (x86)\nanomsg\lib
-  - set PATH=%PATH%;C:\Program Files (x86)\nanomsg\bin
+  - set LIB=%LIB%;C:\Program Files\nanomsg\lib
+  - set PATH=%PATH%;C:\Program Files\nanomsg\bin
   - cargo test
   # Move libnanomsg To Test nanomsg_sys
   - mv ..\nanomsg-1.0.0 .\nanomsg-1.0.0 && cd nanomsg_sys

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,20 +5,25 @@ install:
   # Go To libnanomsg Destination Directory
   - cd ..
   # Download And Compile libnanomsg
-  - ps: Start-FileDownload 'https://github.com/nanomsg/nanomsg/releases/download/0.8-beta/nanomsg-0.8-beta.zip'
-  - 7z x nanomsg-0.8-beta.zip
-  - cd nanomsg-0.8-beta
-  - cmake . && msbuild nanomsg.sln
+  - ps: Start-FileDownload 'https://github.com/nanomsg/nanomsg/archive/0.9-beta.zip'
+  - 7z x 0.9-beta.zip
+  - cd nanomsg-0.9-beta
+  - mkdir build
+  - cd build
+  - cmake ..
+  - cmake -DNN_STATIC_LIB:BOOL=ON --build .
+  - make
+  - make install
   # Fix libnanomsg Library Directory Name
-  - mv .\Debug .\.libs
+  # - mv .\Debug .\.libs
   # Return To nanomsg-rs Git Directory
-  - cd ..\nanomsg-rs
+  - cd ..\..\nanomsg-rs
   # Download And Install Rust
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.6.0-i686-pc-windows-gnu.msi'
-  - msiexec /i rust-1.6.0-i686-pc-windows-gnu.msi /passive /norestart
-  - SET PATH=%PATH%;C:\MinGW\bin
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-x86_64-pc-windows-msvc.msi'
+  - msiexec /i rust-1.8.0-x86_64-pc-windows-msvc.msi /passive /norestart
+  - dir 'C:\Program Files (x86)'
+  - dir ..\nanomsg-0.9-beta\build
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust stable GNU 1.6\bin
-  - gcc -v
   - rustc -V
   - cargo -V
 
@@ -28,5 +33,5 @@ build_script:
 test_script:
   - cargo test
   # Move libnanomsg To Test nanomsg_sys
-  - mv ../nanomsg-0.8-beta ./nanomsg-0.8-beta && cd nanomsg_sys
+  - mv ..\nanomsg-0.9-beta .\nanomsg-0.9-beta && cd nanomsg_sys
   - cargo test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,10 @@
-#os:
-#  - MinGW
-
 install:
   # Go To libnanomsg Destination Directory
   - cd ..
   # Download And Compile libnanomsg
-  - ps: Start-FileDownload 'https://github.com/nanomsg/nanomsg/archive/0.9-beta.zip'
-  - 7z x 0.9-beta.zip
-  - cd nanomsg-0.9-beta
+  - ps: Start-FileDownload 'https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz'
+  - 7z x 1.0.0.tar.gz
+  - cd nanomsg-1.0.0
   - mkdir build
   - cd build
   - cmake ..
@@ -16,8 +13,8 @@ install:
   # Return To nanomsg-rs Git Directory
   - cd ../../nanomsg-rs
   # Download And Install Rust
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-i686-pc-windows-msvc.msi'
-  - start /wait msiexec /i  rust-1.8.0-i686-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.9.0-i686-pc-windows-msvc.msi'
+  - start /wait msiexec /i  rust-1.9.0-i686-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - rustc -V -v
   - cargo -V
@@ -32,5 +29,5 @@ test_script:
   - set PATH=%PATH%;C:\Program Files (x86)\nanomsg\bin
   - cargo test
   # Move libnanomsg To Test nanomsg_sys
-  - mv ..\nanomsg-0.9-beta .\nanomsg-0.9-beta && cd nanomsg_sys
+  - mv ..\nanomsg-1.0.0 .\nanomsg-1.0.0 && cd nanomsg_sys
   - cargo test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,12 +21,12 @@ install:
   # Fix libnanomsg Library Directory Name
   # - mv .\Debug .\.libs
   # Return To nanomsg-rs Git Directory
-  - cd ..\..\nanomsg-rs
+  - cd ../../nanomsg-rs
   # Download And Install Rust
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-x86_64-pc-windows-msvc.msi'
   - msiexec /i rust-1.8.0-x86_64-pc-windows-msvc.msi /passive /norestart
-  - dir 'C:\Program Files (x86)'
-  - dir ..\nanomsg-0.9-beta\build
+  - dir 'C:/Program Files (x86)'
+  - dir ../nanomsg-0.9-beta\build
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust stable GNU 1.6\bin
   - rustc -V
   - cargo -V

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,8 @@ install:
   - cd ../../nanomsg-rs
   # Download And Install Rust
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-x86_64-pc-windows-msvc.msi'
-  - msiexec /i rust-1.8.0-x86_64-pc-windows-msvc.msi /passive /norestart
+  - start /wait msiexec /i  rust-1.8.0-x86_64-pc-windows-msvc.msi INSTALLDIR="C:\Program Files (x86)\Rust" /quiet /qn /passive /norestart
   - dir "C:\Program Files (x86)"
-  - dir ..\nanomsg-0.9-beta\build
-  - set PATH=%PATH%;C:\Program Files (x86)\Rust stable GNU 1.6\bin
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - rustc -V
   - cargo -V

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,10 @@ install:
   # Download And Install Rust
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.8.0-x86_64-pc-windows-msvc.msi'
   - msiexec /i rust-1.8.0-x86_64-pc-windows-msvc.msi /passive /norestart
-  - dir 'C:/Program Files (x86)'
-  - dir ../nanomsg-0.9-beta\build
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust stable GNU 1.6\bin
+  - dir "C:\Program Files (x86)"
+  - dir ..\nanomsg-0.9-beta\build
+  - set PATH=%PATH%;C:\Program Files (x86)\Rust stable GNU 1.6\bin
+  - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - rustc -V
   - cargo -V
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - cmake ..
   - cmake -DNN_STATIC_LIB:BOOL=ON --build .
   - SET PATH=%PATH%;C:\MinGW\bin
+  - echo Current dir is '%CD%'
   - mingw32-make.exe
   - mingw32-make.exe install
   # Fix libnanomsg Library Directory Name

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,12 @@ install:
   - cd build
   - cmake ..
   - cmake -DNN_STATIC_LIB:BOOL=ON --build .
-  - SET PATH=%PATH%;C:\MinGW\bin
-  - echo Current dir is '%CD%'
-  - dir . /s
-  - mingw32-make.exe
-  - mingw32-make.exe install
+  - cmake -DNN_STATIC_LIB:BOOL=ON --build . --target install
+  #- SET PATH=%PATH%;C:\MinGW\bin
+  #- echo Current dir is '%CD%'
+  #- dir . /s
+  #- mingw32-make.exe
+  #- mingw32-make.exe install
   # Fix libnanomsg Library Directory Name
   # - mv .\Debug .\.libs
   # Return To nanomsg-rs Git Directory

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -1,0 +1,44 @@
+extern crate nanomsg;
+
+use nanomsg::{Socket, Protocol};
+use std::thread;
+
+use std::io::{Read, Write};
+
+fn main() {
+
+    let srv = thread::spawn(move || {
+        println!("server: create socket");
+        let mut s = Socket::new(Protocol::Pull).unwrap();
+        println!("server: bind socket");
+        //s.bind(&"inproc://test").unwrap();
+        s.bind(&"tcp://127.0.0.1:5456").unwrap();
+
+        println!("server: sleep 500");
+        thread::sleep_ms(500);
+
+        let mut msg = String::new();
+        println!("server: recv");
+        s.read_to_string(&mut msg).unwrap();
+        println!("server: msg: {}", msg);
+    });
+
+    println!("client: sleep 100");
+    // let the server start
+    thread::sleep_ms(100);
+
+    println!("client: create socket");
+    let mut s = Socket::new(Protocol::Push).unwrap();
+    println!("client: connect socket");
+    //let mut ep = s.connect(&"inproc://test").unwrap();
+    let mut ep = s.connect(&"tcp://127.0.0.1:5456").unwrap();
+    println!("client: set_linger");
+    s.set_linger(-1).expect("cannot set linger");
+    println!("client: write_all");
+    s.write_all("hello nanomsg".as_bytes()).unwrap();
+    println!("client: shutdown");
+    ep.shutdown().expect("cannot shutdown");
+    println!("client: wait server");
+
+    srv.join();
+}

--- a/examples/puller.rs
+++ b/examples/puller.rs
@@ -1,0 +1,45 @@
+extern crate nanomsg;
+
+use nanomsg::{Socket, Protocol};
+
+use std::thread;
+
+use std::io::Read;
+
+
+fn puller(url: &str) {
+    let mut input = Socket::new(Protocol::Pull).unwrap();
+    let mut msg = String::new();
+
+    input.bind(url).unwrap();
+    println!("Puller listen on '{}'.", url);
+
+    loop {
+        match input.read_to_string(&mut msg) {
+            Ok(_) => {
+                println!("Puller received '{}'.", msg);
+
+                thread::sleep_ms(1000); // fake some work ...
+                msg.clear();
+            },
+            Err(err) => {
+                println!("Puller failed '{}'.", err);
+                break;
+            }
+        }
+    }
+}
+
+fn usage() {
+    println!("Usage: puller $url");
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+
+    if args.len() < 2 {
+        return usage()
+    }
+
+    puller(args[1].as_ref());
+}

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "nanomsg-sys"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   "Daniel Fagnan <dnfagnan@gmail.com>",
   "Benoît Labaere <benoit.labaere@gmail.com>"
@@ -17,4 +17,4 @@ links = "nanomsg"
 build = "build.rs"
 
 [dependencies]
-libc = "0.2.5"
+libc = "0.2.11"

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -1,4 +1,13 @@
+#[cfg(not(windows))]
 fn main() {
+    println!("cargo:rustc-flags=-L /usr/local/lib -l nanomsg");
+}
+
+#[cfg(windows)]
+fn main() {
+    println!("cargo:rustc-flags=-L 'C:/Program Files (x86)/nanomsg/lib' -L 'C:/Program Files (x86)/nanomsg/bin' -l nanomsg");
+}
+
     // let target = env::var("TARGET").unwrap();
     // let windows = target.contains("windows");
     //
@@ -8,6 +17,5 @@ fn main() {
     //    println!("cargo:rustc-flags=-L /usr/local/lib -l nanomsg");
     // }
     // TODO : see https://github.com/thehydroimpulse/nanomsg.rs/issues/143
+    // https://github.com/alexcrichton/git2-rs/blob/master/libgit2-sys/build.rs#L29
     // Using pkg-config seems like a good idea
-    println!("cargo:rustc-flags=-L /usr/local/lib -l nanomsg");
-}

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -1,3 +1,13 @@
 fn main() {
-    println!("cargo:rustc-flags=-L ../nanomsg-0.9-beta/build -l nanomsg");
+    // let target = env::var("TARGET").unwrap();
+    // let windows = target.contains("windows");
+    //
+    // if windows {
+    //    ???
+    // } else {
+    //    println!("cargo:rustc-flags=-L /usr/local/lib -l nanomsg");
+    // }
+    // TODO : see https://github.com/thehydroimpulse/nanomsg.rs/issues/143
+    // Using pkg-config seems like a good idea
+    println!("cargo:rustc-flags=-L /usr/local/lib -l nanomsg");
 }

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -5,7 +5,8 @@ fn main() {
 
 #[cfg(windows)]
 fn main() {
-    println!("cargo:rustc-flags=-L 'C:/Program Files (x86)/nanomsg/lib' -L 'C:/Program Files (x86)/nanomsg/bin' -l nanomsg");
+    println!("cargo:rustc-link-lib=nanomsg");
+    println!("cargo:rustc-link-search=C:/Program Files (x86)/nanomsg/lib");
 }
 
     // let target = env::var("TARGET").unwrap();

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("cargo:rustc-flags=-L ../nanomsg-0.8-beta/.libs -l nanomsg");
+    println!("cargo:rustc-flags=-L ../nanomsg-0.9-beta/build -l nanomsg");
 }

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types, non_snake_case)]
-//#[link(name = "nanomsg", kind = "static")]
 #[link(name = "nanomsg")]
 
 extern crate libc;

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -306,6 +306,10 @@ mod tests {
     use std::ffi::CStr;
     use std::str;
 
+    fn sleep_ms(millis: u64) {
+        thread::sleep(::std::time::Duration::from_millis(millis));
+    }
+
     fn test_create_socket(domain: c_int, protocol: c_int) -> c_int {
         let sock = unsafe { nn_socket(domain, protocol) };
         assert!(sock >= 0);
@@ -415,7 +419,7 @@ mod tests {
         let sock3 = test_create_socket(AF_SP, NN_BUS);
         let sock3_read_endpoint = test_connect(sock3, url.as_ptr() as *const i8);
 
-        thread::sleep_ms(10);
+        sleep_ms(10);
 
         let msg = "foobar";
         test_send(sock1, msg);
@@ -450,7 +454,7 @@ mod tests {
         let topic2 = "bar";
         test_subscribe(sub_sock2, topic2);
 
-        thread::sleep_ms(100);
+        sleep_ms(100);
 
         let msg1 = "foobar";
         test_send(pub_sock, msg1);
@@ -484,7 +488,7 @@ mod tests {
         let resp_sock2 = test_create_socket(AF_SP, NN_RESPONDENT);
         let resp_endpoint2 = test_connect(resp_sock2, url.as_ptr() as *const i8);
 
-        thread::sleep_ms(10);
+        sleep_ms(10);
 
         let survey = "are_you_there";
         test_send(surv_sock, survey);
@@ -526,7 +530,7 @@ mod tests {
 
         test_bind(s1, url.as_ptr() as *const i8);
         test_connect(s2, url.as_ptr() as *const i8);
-        thread::sleep_ms(10);
+        sleep_ms(10);
 
         let poll_result2 = unsafe { nn_poll(fd_ptr, 2, 10) as usize };
         assert_eq!(2, poll_result2);
@@ -535,7 +539,7 @@ mod tests {
 
         let msg = "foobar";
         test_send(s2, msg);
-        thread::sleep_ms(10);
+        sleep_ms(10);
 
         let poll_result3 = unsafe { nn_poll(fd_ptr, 2, 10) as usize };
         assert_eq!(2, poll_result3);

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types, non_snake_case)]
-#[link(name = "nanomsg", kind = "static")]
+//#[link(name = "nanomsg", kind = "static")]
+#[link(name = "nanomsg")]
 
 extern crate libc;
 

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types, non_snake_case)]
-#[link(name = "nanomsg")]
+#[link(name = "nanomsg", kind = "static")]
 
 extern crate libc;
 

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types, non_snake_case)]
-#[link(name = "nanomsg")]
 
 extern crate libc;
 
@@ -170,6 +169,7 @@ impl nn_pollfd {
     }
 }
 
+#[link(name = "nanomsg")]
 extern {
     /// "Creates an SP socket with specified domain and protocol. Returns
     /// a file descriptor for the newly created socket."

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types, non_snake_case)]
-#[link(name = "nanomsg", kind = "static")]
+#[link(name = "nanomsg")]
 
 extern crate libc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1846,6 +1846,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn should_get_socket_name() {
         let mut socket = test_create_socket(Pair);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1850,6 +1850,11 @@ mod tests {
     fn should_get_socket_name() {
         let mut socket = test_create_socket(Pair);
 
+        match socket.set_socket_name("bob") {
+            Ok(..) => {},
+            Err(err) => panic!("Failed to change the socket name: {}", err)
+        }
+
         match socket.get_socket_name(1024) {
             Ok(..) => {},
             Err(err) => panic!("Failed to get socket name: {}", err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1789,6 +1789,7 @@ mod tests {
         drop(socket)
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn should_change_socket_name() {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,7 @@ impl Socket {
     /// Socket name for error reporting and statistics.
     /// Default value is "socket.N" where N is socket integer.
     /// **This option is experimental, see `Socket::env` for details**
+    #[cfg(not(windows))]
     pub fn set_socket_name(&mut self, name: &str) -> Result<()> {
         self.set_socket_options_str(nanomsg_sys::NN_SOL_SOCKET,
                                     nanomsg_sys::NN_SOCKET_NAME,
@@ -905,6 +906,7 @@ impl Socket {
     /// Retrieve the name for this socket for error reporting and
     /// statistics.
     /// **This option is experimental, see `Socket::env` for details
+    #[cfg(not(windows))]
     pub fn get_socket_name(&mut self, len: usize) -> Result<String> {
         self.get_socket_option_str(nanomsg_sys::NN_SOL_SOCKET,
                                    nanomsg_sys::NN_SOCKET_NAME,
@@ -1846,7 +1848,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(windows))]
+    #[cfg(not(windows))] // Crashes during appveyor build
     #[test]
     fn should_get_socket_name() {
         let mut socket = test_create_socket(Pair);


### PR DESCRIPTION
Obviously:
 - Upgrade nanomsg native dependency to version 1.0.0

But also:
- libnanomsg is now used as dynamic library
- libnanomsg is now built using cmake (as recommended since 0.9)

The Windows build on Appveyor changed too:
- Using Visual Studio instead of mingw
- Moved to x64