### PR TITLE
Don't dynamic link to libnanomsg when using 'bundled' feature

### DIFF
--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -31,6 +31,7 @@ fn main() {
     }
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib64", dst.display());
 }
 
 #[cfg(not(feature = "bundled"))]

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -169,7 +169,9 @@ impl nn_pollfd {
     }
 }
 
-#[link(name = "nanomsg")]
+#[cfg_attr(all(target_os = "linux", feature = "bundled"), link(name = "anl"))]
+#[cfg_attr(not(feature = "bundled"), link(name = "nanomsg"))]
+#[cfg_attr(feature = "bundled", link(name = "nanomsg", kind = "static"))]
 extern {
     /// "Creates an SP socket with specified domain and protocol. Returns
     /// a file descriptor for the newly created socket."


### PR DESCRIPTION
With 'bundled', no need to dynamic link to `libnanomsg.so` .