### PR TITLE
Fixes libc imports on various OSes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ path = "./nanomsg_sys"
 version = "0.7.0"
 
 [dependencies]
-libc = "0.2.11"
+libc = "0.2.18"

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -21,7 +21,7 @@ build = "build.rs"
 bundled = []
 
 [dependencies]
-libc = "0.2.11"
+libc = "0.2.18"
 
 [build-dependencies]
 gcc = "0.3"

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -3,9 +3,6 @@ extern crate gcc;
 extern crate pkg_config;
 
 use std::env;
-use std::path::Path;
-use std::process::Command;
-
 
 #[cfg(feature = "bundled")]
 fn main() {
@@ -13,9 +10,9 @@ fn main() {
 
     // TODO: Determine whether we'd rather always do a fresh clone.
     // TODO: Determine whether we wouldn't rather use a submodule.
-    if !Path::new("nanomsg/.git").exists() {
+    if !::std::path::Path::new("nanomsg/.git").exists() {
         // Panic if we can't clone nanomsg
-        let _ = Command::new("git")
+        let _ = ::std::process::Command::new("git")
             .args(&["clone", "-b", "1.0.0", "--depth", "1", "https://github.com/nanomsg/nanomsg.git"])
             .status().unwrap();
     }

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -97,14 +97,6 @@ pub mod posix_consts {
     pub const EISCONN:         c_int = NN_HAUSNUMERO + 27;
     pub const ESOCKTNOSUPPORT: c_int = NN_HAUSNUMERO + 28;
     
-    pub const EINTR:           c_int = 4;
-    pub const EBADF:           c_int = 9;
-    pub const EAGAIN:          c_int = 11;
-    pub const EFAULT:          c_int = 14;
-    pub const ENODEV:          c_int = 19;
-    pub const EINVAL:          c_int = 22;
-    pub const EMFILE:          c_int = 24;
-    pub const ENAMETOOLONG:    c_int = 38;
     pub const EADDRINUSE:      c_int = 100;
     pub const EADDRNOTAVAIL:   c_int = 101;
     pub const EAFNOSUPPORT:    c_int = 102;

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -81,9 +81,6 @@ pub mod posix_consts {
     // Use the value from the windows definitions if an override is required.
     pub const NN_HAUSNUMERO: c_int = 156384712;
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    pub const ENOTSUP: c_int = NN_HAUSNUMERO + 1;
-
     // nanomsg uses EACCESS as an alias for EACCES
     pub const EACCESS: c_int = ::libc::EACCES;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1598,11 +1598,13 @@ mod tests {
         test_subscribe(&mut sock3, "bar");
         test_connect(&mut sock3, url);
 
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(150));
 
         let msg1 = b"foobar";
         test_write(&mut sock1, msg1);
         test_read(&mut sock2, msg1);
+
+        thread::sleep(Duration::from_millis(100));
 
         let msg2 = b"barfoo";
         test_write(&mut sock1, msg2);


### PR DESCRIPTION
This PR fixes the build with the latest libc, on debian and windows.
It removes several constants that are now defined in libc.