### PR TITLE
Add NN_RCVMAXSIZE socket option and set_receive_max_size() call

### DIFF
--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -50,6 +50,7 @@ pub const NN_DOMAIN: c_int = 12;
 pub const NN_PROTOCOL: c_int = 13;
 pub const NN_IPV4ONLY: c_int = 14;
 pub const NN_SOCKET_NAME: c_int = 15;
+pub const NN_RCVMAXSIZE: c_int = 16;
 
 pub const NN_DONTWAIT: c_int = 1;
 
@@ -664,6 +665,7 @@ mod tests {
             "NN_PROTOCOL" => Some(NN_PROTOCOL),
             "NN_IPV4ONLY" => Some(NN_IPV4ONLY),
             "NN_SOCKET_NAME" => Some(NN_SOCKET_NAME),
+            "NN_RCVMAXSIZE" => Some(NN_RCVMAXSIZE),
             "NN_DONTWAIT" => Some(NN_DONTWAIT),
             "NN_INPROC" => Some(NN_INPROC),
             "NN_IPC" => Some(NN_IPC),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,6 +791,15 @@ impl Socket {
                                       size_in_bytes as c_int)
     }
 
+    /// Maximum message size that can be received, in bytes. Negative value means that the received size
+    /// is limited only by available addressable memory.
+    /// Default is 1024kB.
+    pub fn set_receive_max_size(&mut self, size_in_bytes: isize) -> Result<()> {
+        self.set_socket_options_c_int(nanomsg_sys::NN_SOL_SOCKET,
+                                      nanomsg_sys::NN_RCVMAXSIZE,
+                                      size_in_bytes as c_int)
+    }
+
     /// The timeout for send operation on the socket.
     /// If message cannot be sent within the specified timeout, TryAgain error is returned.
     /// Negative value means infinite timeout. Default value is infinite timeout.


### PR DESCRIPTION
This commit provides interface to alter maximum size of message that
can be received. Messages larger than the specified size are silently
dropped. The API appeared in nanomsg v0.7 along with default size
of 1024K.