### PR TITLE
Add config option to drop libanl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ keywords = ["nanomsg", "binding", "network", "pub", "sub"]
 license = "MIT"
 
 [features]
+default = ["getaddrinfo_a"]
+
 bundled = ["nanomsg-sys/bundled"]
+getaddrinfo_a = ["nanomsg-sys/getaddrinfo_a"]
 
 [dependencies.nanomsg-sys]
 path = "./nanomsg_sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,8 @@ keywords = ["nanomsg", "binding", "network", "pub", "sub"]
 license = "MIT"
 
 [features]
-default = ["getaddrinfo_a"]
-
 bundled = ["nanomsg-sys/bundled"]
-getaddrinfo_a = ["nanomsg-sys/getaddrinfo_a"]
+no_anl = ["nanomsg-sys/no_anl"]
 
 [dependencies.nanomsg-sys]
 path = "./nanomsg_sys"

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -18,9 +18,8 @@ links = "nanomsg"
 build = "build.rs"
 
 [features]
-default = ["getaddrinfo_a"]
 bundled = []
-getaddrinfo_a = []
+no_anl = []
 
 [dependencies]
 libc = "0.2.18"

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -18,7 +18,9 @@ links = "nanomsg"
 build = "build.rs"
 
 [features]
+default = ["getaddrinfo_a"]
 bundled = []
+getaddrinfo_a = []
 
 [dependencies]
 libc = "0.2.18"

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -17,9 +17,16 @@ fn main() {
             .status().unwrap();
     }
 
+    let getaddrinfo_a_flag = if cfg!(feature = "getaddrinfo_a") {
+      "ON"
+    } else {
+      "OFF"
+    };
+
     let dst = cmake::Config::new("nanomsg")
         .define("NN_STATIC_LIB", "ON")
         .define("NN_ENABLE_DOC", "OFF")
+        .define("NN_ENABLE_GETADDRINFO_A", getaddrinfo_a_flag)
         .define("NN_TESTS", "OFF")
         .build();
 

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -17,10 +17,10 @@ fn main() {
             .status().unwrap();
     }
 
-    let getaddrinfo_a_flag = if cfg!(feature = "getaddrinfo_a") {
-      "ON"
-    } else {
+    let getaddrinfo_a_flag = if cfg!(feature = "no_anl") {
       "OFF"
+    } else {
+      "ON"
     };
 
     let dst = cmake::Config::new("nanomsg")

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -89,7 +89,7 @@ pub mod posix_consts {
 #[cfg(windows)]
 pub mod posix_consts {
     use libc::c_int;
-    
+
     pub const NN_HAUSNUMERO: c_int = 156384712;
 
     pub const ENOTSUP:         c_int = NN_HAUSNUMERO + 1;
@@ -97,7 +97,7 @@ pub mod posix_consts {
     pub const EACCESS:         c_int = NN_HAUSNUMERO + 17;
     pub const EISCONN:         c_int = NN_HAUSNUMERO + 27;
     pub const ESOCKTNOSUPPORT: c_int = NN_HAUSNUMERO + 28;
-    
+
     pub const EADDRINUSE:      c_int = 100;
     pub const EADDRNOTAVAIL:   c_int = 101;
     pub const EAFNOSUPPORT:    c_int = 102;
@@ -159,7 +159,7 @@ impl nn_pollfd {
     }
 }
 
-#[cfg_attr(all(target_os = "linux", feature = "bundled"), link(name = "anl"))]
+#[cfg_attr(all(target_os = "linux", feature = "bundled", feature = "getaddrinfo_a"), link(name = "anl"))]
 #[cfg_attr(not(feature = "bundled"), link(name = "nanomsg"))]
 #[cfg_attr(feature = "bundled", link(name = "nanomsg", kind = "static"))]
 extern {

--- a/nanomsg_sys/src/lib.rs
+++ b/nanomsg_sys/src/lib.rs
@@ -159,7 +159,7 @@ impl nn_pollfd {
     }
 }
 
-#[cfg_attr(all(target_os = "linux", feature = "bundled", feature = "getaddrinfo_a"), link(name = "anl"))]
+#[cfg_attr(all(target_os = "linux", feature = "bundled", not(feature = "no_anl")), link(name = "anl"))]
 #[cfg_attr(not(feature = "bundled"), link(name = "nanomsg"))]
 #[cfg_attr(feature = "bundled", link(name = "nanomsg", kind = "static"))]
 extern {


### PR DESCRIPTION
@blabaere I was trying to bundle nanomsg statically for an arm+musl target, and it looks like there was no way to turn off the optional cmake `NN_ENABLE_GETADDRINFO_A` flag, which requires us to link to libanl. This simply adds an optional config feature `no_anl` that sets that flag to 'OFF', falling back from the libanl `getaddrinfo_a` to the musl-compatible `getaddrinfo`.