### PR TITLE
Bundling nanomsg 1.1.2 and build.rs cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanomsg"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
   "Daniel Fagnan <dnfagnan@gmail.com>",
   "Jason E. Aten",
@@ -31,7 +31,7 @@ no_anl = ["nanomsg-sys/no_anl"]
 
 [dependencies.nanomsg-sys]
 path = "./nanomsg_sys"
-version = "0.6.2"
+version = "0.6.3"
 
 [dependencies]
-libc = "0.2.18"
+libc = "0.2.*"

--- a/nanomsg_sys/Cargo.toml
+++ b/nanomsg_sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "nanomsg-sys"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
   "Daniel Fagnan <dnfagnan@gmail.com>",
   "Benoît Labaere <benoit.labaere@gmail.com>",
@@ -22,9 +22,9 @@ bundled = []
 no_anl = []
 
 [dependencies]
-libc = "0.2.18"
+libc = "0.2.*"
 
 [build-dependencies]
-gcc = "0.3"
-cmake = "0.1.22"
-pkg-config = "0.3"
+gcc = "0.3.*"
+cmake = "0.1.*"
+pkg-config = "0.3.*"


### PR DESCRIPTION
Updating other dependencies and avoiding locking patch-version
according to general cargo-guidelines for libraries.

Bumping version to 0.6.3