### PR TITLE
Fix static build of bundled nanomsg

### DIFF
--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -59,13 +59,18 @@ fn main() {
         "ON"
     };
 
-    let dst = cmake::Config::new(clone_path)
+    let mut config = cmake::Config::new(clone_path);
+    config
         .define("NN_STATIC_LIB", "ON")
         .define("NN_ENABLE_DOC", "OFF")
         .define("NN_ENABLE_GETADDRINFO_A", getaddrinfo_a_flag)
-        .define("NN_TESTS", "OFF")
-        .define("CMAKE_SKIP_INSTALL_RPATH", "ON")
-        .build();
+        .define("NN_TESTS", "OFF");
+
+    if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl" {
+        config.define("CMAKE_SKIP_INSTALL_RPATH", "ON");
+    }
+
+    let dst = config.build();
 
     if target.contains("windows") {
         println!("cargo:rustc-link-lib=mswsock");

--- a/nanomsg_sys/build.rs
+++ b/nanomsg_sys/build.rs
@@ -64,6 +64,7 @@ fn main() {
         .define("NN_ENABLE_DOC", "OFF")
         .define("NN_ENABLE_GETADDRINFO_A", getaddrinfo_a_flag)
         .define("NN_TESTS", "OFF")
+        .define("CMAKE_SKIP_INSTALL_RPATH", "ON")
         .build();
 
     if target.contains("windows") {


### PR DESCRIPTION
When building with musl as a target, build fails like so:

```
% cargo build --target=x86_64-unknown-linux-musl --release

...

CMake Error at cmake_install.cmake:94 (file):
  file RPATH_CHANGE could not write new RPATH:

    /home/user/rust/project/target/x86_64-unknown-linux-musl/release/build/nanomsg-sys-80e249f9b2c26403/out/lib64

  to the file:

    /home/user/rust/project/target/x86_64-unknown-linux-musl/release/build/nanomsg-sys-80e249f9b2c26403/out/bin/nanocat

  No valid ELF RPATH or RUNPATH entry exists in the file;

...

```

A hint can be found in https://github.com/FreeRDP/FreeRDP/issues/2150.
This patch seems to fix this issue here, and I can build a working static binary.